### PR TITLE
Criação de mapas em tempo de execução

### DIFF
--- a/backend/common/views.py
+++ b/backend/common/views.py
@@ -9,17 +9,79 @@ from django.shortcuts import redirect
 from rest_framework.decorators import action, renderer_classes, api_view
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
+from datetime import datetime, timezone
+import dateutil.parser
 
 from tno.tasks import teste_api_task
+from sora.prediction.occmap import plot_occ_map as occmap
 
 @api_view(["GET"])
 def teste(request):
     if request.method == "GET":
-        result = dict(
-            {
-                "success": True,
-            }
-        )
+        # ORIGINAL VALUES
+        name = "Chiron"
+        diameter = None
+        ra_star_candidate = "00 47 31.2926"
+        dec_star_candidate = "+06 50 46.320"
+        date_time = dateutil.parser.isoparse("2023-02-27T08:36:40Z")
+        closest_approach = 0.215
+        position_angle = 159.27
+        velocity = 29.66
+        delta = 19.6
+        g = 19.1
+        long = 131.0
+
+        # FORMATED VALUES
+        radius = diameter if diameter != None else 0
+        coord = f"{ra_star_candidate}{dec_star_candidate}"
+        time = date_time              
+        ca = closest_approach 
+        pa = position_angle
+        vel = velocity
+        dist = delta
+        mag = g
+        longi = long
+        dpi=50
+        nameimg='image_filename' 
+        path='/archive/tmp'
+        fmt='jpg'
+
+        occmap(
+            name, 
+            radius, 
+            coord, 
+            time, 
+            ca, 
+            pa, 
+            vel, 
+            dist, 
+            mag=mag, 
+            longi=longi, 
+            dpi=50,  
+            nameimg='image_filename', 
+            path=path, 
+            fmt='jpg')
+
+        result = {
+            "success": True,
+            "name": name,
+            "radius": radius,
+            "coord": coord,
+            "time": time,
+            "ca": ca,
+            "pa": pa,
+            "vel": vel,
+            "dist": dist,
+            "mag": mag,
+            "longi": longi,
+            "dpi": dpi,
+            "nameimg": nameimg,
+            "path": path,
+            "fmt": fmt,
+            # "data_url": data_url
+        }
+        # data_url = settings.DATA_TMP_URL
+
         return Response(result)
 
 @api_view(["GET"])

--- a/backend/coreAdmin/settings.py
+++ b/backend/coreAdmin/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 
 import os
 import urllib.parse
+from pathlib import Path
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -24,16 +25,16 @@ BIN_DIR = os.path.join(BASE_DIR, "bin")
 # os mesmos listados aqui.
 LOG_DIR = "/log"
 LOGGING_LEVEL = "INFO"
-ARCHIVE_DIR = "/archive"
+ARCHIVE_DIR = Path("/archive")
 PROCCESS_DIR = "/proccess"
 DES_CCD_CATALOGS_DIR = "/archive/des/public/catalogs/"
 
 # Sub diretorios que ficam dentro de /archive
 
 SKYBOT_ROOT = "skybot_output"
-SKYBOT_OUTPUT = os.path.join(ARCHIVE_DIR, SKYBOT_ROOT)
-if not os.path.exists(SKYBOT_OUTPUT):
-    os.mkdir(SKYBOT_OUTPUT)
+SKYBOT_OUTPUT = Path.joinpath(ARCHIVE_DIR, SKYBOT_ROOT)
+if not SKYBOT_OUTPUT.exists():
+    SKYBOT_OUTPUT.mkdir(parents=True, exist_ok=False)
 
 # JHONSTONS_ARCHIVE_ROOT = "jhonstons_archive"
 # JHONSTONS_ARCHIVE = os.path.join(ARCHIVE_DIR, JHONSTONS_ARCHIVE_ROOT)
@@ -43,15 +44,23 @@ if not os.path.exists(SKYBOT_OUTPUT):
 MEDIA_ROOT = ARCHIVE_DIR
 MEDIA_URL = "/media/"
 
-MEDIA_TMP_DIR = os.path.join(MEDIA_ROOT, "tmp")
-if not os.path.exists(MEDIA_TMP_DIR):
-    os.mkdir(MEDIA_TMP_DIR)
+MEDIA_TMP_DIR = Path.joinpath(MEDIA_ROOT, "tmp")
+if not MEDIA_TMP_DIR.exists():
+    MEDIA_TMP_DIR.mkdir(parents=True, exist_ok=False)
 
 MEDIA_TMP_URL = urllib.parse.urljoin(MEDIA_URL, "tmp/")
 
 DATA_URL = "/data/"
 DATA_TMP_DIR = MEDIA_TMP_DIR
 DATA_TMP_URL = urllib.parse.urljoin(DATA_URL, "tmp/")
+
+OCCULTATION_URL = "maps/"
+OCCULTATION_MAP_DIR = MEDIA_TMP_DIR.joinpath("maps")
+if not OCCULTATION_MAP_DIR.exists():
+    OCCULTATION_MAP_DIR.mkdir(parents=True, exist_ok=False)
+
+OCCULTATION_MAP_URL = urllib.parse.urljoin(DATA_TMP_URL, OCCULTATION_URL)
+
 
 ENVIRONMENT_NAME = os.environ.get("ENVIRONMENT_NAME", "Development")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,9 +3,11 @@ APScheduler==3.9.1.post1
 asgiref==3.5.2
 astropy==5.1.1
 astroquery==0.4.6
+attrs==23.1.0
 beautifulsoup4==4.12.1
 billiard==3.6.4.0
 cached-property==1.5.2
+Cartopy==0.22.0
 celery==5.2.7
 certifi==2022.9.24
 cffi==1.15.1
@@ -14,6 +16,7 @@ click==8.1.3
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.2.0
+cligj==0.7.2
 contourpy==1.0.6
 cron-descriptor==1.4.0
 cryptography==40.0.1
@@ -29,6 +32,7 @@ django-timezone-field==5.0
 django-url-filter==0.3.15
 djangorestframework==3.14.0
 enum-compat==0.0.3
+Fiona==1.9.4.post1
 flower==1.2.0
 fonttools==4.38.0
 greenlet==2.0.1
@@ -46,6 +50,7 @@ lxml==4.9.1
 matplotlib==3.6.2
 more-itertools==9.1.0
 numpy==1.23.4
+OWSLib==0.29.2
 packaging==21.3
 pandas==1.5.1
 Pillow==9.3.0
@@ -55,7 +60,10 @@ prompt-toolkit==3.0.38
 psycopg2-binary==2.9.5
 pycparser==2.21
 pyerfa==2.0.0.1
+pykdtree==1.3.9
 pyparsing==3.0.9
+pyproj==3.6.1
+pyshp==2.3.1
 python-crontab==2.7.1
 python-dateutil==2.8.2
 pytz==2022.6
@@ -65,13 +73,16 @@ PyYAML==6.0
 requests==2.28.1
 scipy==1.9.3
 SecretStorage==3.3.3
+shapely==2.0.1
 six==1.16.0
+sora-astro==0.3
 soupsieve==2.4
 spiceypy==5.1.2
 SQLAlchemy==1.4.44
 sqlparse==0.4.3
 tenacity==8.2.2
 tornado==6.3.2
+tqdm==4.66.1
 tzdata==2022.6
 tzlocal==4.2
 urllib3==1.26.12

--- a/backend/tno/models.py
+++ b/backend/tno/models.py
@@ -5,7 +5,9 @@ from current_user import get_current_user
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-
+from django.conf import settings
+from pathlib import Path
+import urllib.parse
 class Profile(models.Model):
     class Meta:
         verbose_name_plural = "profile"
@@ -66,6 +68,10 @@ class Asteroid(models.Model):
             return "%s (%s)" % (self.name, self.number)
         else:
             return self.name
+
+    def get_alias(self):
+        alias = self.name.replace(" ", "").replace("_", "").replace("/", "")
+        return alias
 
 
 class Occultation(models.Model):
@@ -517,6 +523,21 @@ class Occultation(models.Model):
         help_text="Aphelion",
     )
 
+    def get_alias(self):
+        return self.asteroid.get_alias()
+
+    def get_map_filename(self):
+        dt = self.date_time.strftime("%Y%m%d_%H%M%S")
+        return f"{self.get_alias()}_{dt}.jpg"
+  
+    def get_map_filepath(self):
+        return Path.joinpath(settings.OCCULTATION_MAP_DIR, self.get_map_filename())
+
+    def get_map_relative_url(self):
+        if self.get_map_filepath().exists():
+            return  urllib.parse.urljoin(settings.OCCULTATION_MAP_URL, self.get_map_filename())
+        else:
+            return None
 
 class LeapSecond(models.Model):
     class Meta:

--- a/backend/tno/serializers.py
+++ b/backend/tno/serializers.py
@@ -1,14 +1,16 @@
-from skybot.models.position import Position
 import humanize
 from django.contrib.auth.models import User
 from rest_framework import serializers
+from skybot.models.position import Position
 
-from tno.models import JohnstonArchive
-from tno.models import Asteroid, Occultation, LeapSecond, BspPlanetary, Catalog, PredictionJob, PredictionJobResult, PredictionJobStatus, Profile
+from tno.models import (Asteroid, BspPlanetary, Catalog, JohnstonArchive,
+                        LeapSecond, Occultation, PredictionJob,
+                        PredictionJobResult, PredictionJobStatus, Profile)
 
 
 class UserSerializer(serializers.ModelSerializer):
     dashboard = serializers.SerializerMethodField()
+
     class Meta:
         model = User
         fields = ("username", "dashboard")
@@ -48,6 +50,7 @@ class JohnstonArchiveSerializer(serializers.ModelSerializer):
             "updated",
         )
 
+
 class LeapSecondSerializer(serializers.ModelSerializer):
     class Meta:
         model = LeapSecond
@@ -59,6 +62,7 @@ class BspPlanetarySerializer(serializers.ModelSerializer):
         model = BspPlanetary
         fields = '__all__'
 
+
 class CatalogSerializer(serializers.ModelSerializer):
     class Meta:
         model = Catalog
@@ -67,6 +71,7 @@ class CatalogSerializer(serializers.ModelSerializer):
             "name",
             "display_name"
         )
+
 
 class AsteroidSerializer(serializers.ModelSerializer):
     class Meta:
@@ -82,12 +87,28 @@ class AsteroidSerializer(serializers.ModelSerializer):
 
 class OccultationSerializer(serializers.ModelSerializer):
     dynclass = serializers.CharField(source='asteroid.dynclass')
+    alias = serializers.SerializerMethodField()
+    map_url = serializers.SerializerMethodField()
+
     class Meta:
         model = Occultation
         fields = '__all__'
 
+    def get_alias(self, obj):
+        return obj.get_alias()
+
+    def get_map_url(self, obj):
+        request = self.context.get("request")
+        relative_url = obj.get_map_relative_url()
+        if relative_url == None:
+            return None
+        # Convert to absolute url
+        return request.build_absolute_uri(relative_url)
+
+
 class PredictionJobSerializer(serializers.ModelSerializer):
     owner = serializers.SerializerMethodField()
+
     class Meta:
         model = PredictionJob
         fields = '__all__'
@@ -103,6 +124,7 @@ class PredictionJobResultSerializer(serializers.ModelSerializer):
     class Meta:
         model = PredictionJobResult
         fields = '__all__'
+
 
 class PredictionJobStatusSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/tno/sora_map.py
+++ b/backend/tno/sora_map.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from sora.prediction.occmap import plot_occ_map as occmap
+
+
+def sora_occultation_map(
+        name: str,
+        diameter: Optional[float],
+        ra_star_candidate: str,
+        dec_star_candidate: str,
+        date_time: datetime,
+        closest_approach: float,
+        position_angle: float,
+        velocity: float,
+        delta: float,
+        g: float,
+        long: float,
+        filepath: Path,
+        dpi: int = 50):
+
+    filename = filepath.name
+    fname, fmt = filename.split('.')
+    path = filepath.parent
+
+    radius = float(diameter / 2) if diameter != None else 0
+    coord = f"{ra_star_candidate}{dec_star_candidate}"
+    # Time format is isoformat in UTC withou +00:00
+    # ex: 2023-09-26T00:54:13.683590Z
+    time = date_time.isoformat().replace("+00:00", "Z")
+    occmap(
+        name=name,
+        radius=radius,
+        coord=coord,
+        time=time,
+        ca=closest_approach,
+        pa=position_angle,
+        vel=velocity,
+        dist=delta,
+        mag=g,
+        longi=long,
+        dpi=dpi,
+        nameimg=fname,
+        path=path,
+        fmt=fmt)
+
+    filepath = path.joinpath(filename)
+    if filepath.exists():
+        return filepath
+    else:
+        raise Exception(f"Map file was not generated. {filepath}")

--- a/backend/tno/tasks.py
+++ b/backend/tno/tasks.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 import os
 import json
+from tno.sora_map import sora_occultation_map
 
 
 # Example task
@@ -29,6 +30,12 @@ def teste_periodic_task():
 def teste_api_task():
     print(f"Executou Tarefa submetida pela API. {datetime.now()}")
     return True
+
+@shared_task
+def create_occ_map_task(**kwargs):
+    return sora_occultation_map(**kwargs)
+    
+
 
 # task para gerar os mapas das ocultações todos os dias as 23:00
 # a task tentará gerar os mapas das 50 primeiras ocultações do próximo dia

--- a/backend/tno/views/occultation.py
+++ b/backend/tno/views/occultation.py
@@ -71,7 +71,7 @@ class OccultationViewSet(viewsets.ReadOnlyModelViewSet):
     ordering = ("date_time",)
 
     @action(detail=True, methods=["get"], permission_classes=(AllowAny,))
-    def create_map(self, request, pk):
+    def get_or_create_map(self, request, pk):
         obj = self.get_object()
 
         filepath = obj.get_map_filepath()

--- a/backend/tno/views/occultation.py
+++ b/backend/tno/views/occultation.py
@@ -1,41 +1,52 @@
-import django_filters
-from rest_framework import viewsets
-from rest_framework.authentication import (
-    BasicAuthentication,
-    SessionAuthentication,
-    TokenAuthentication,
-)
-from rest_framework.permissions import IsAuthenticated, AllowAny
-
-from tno.models import Occultation
-from tno.serializers import OccultationSerializer
-from rest_framework.decorators import action
-from rest_framework.response import Response
-from datetime import datetime
-from rest_framework.pagination import PageNumberPagination
-from operator import  attrgetter
-from tno.occviz import visibility
-from django.conf import settings
 import time
-from tno.db import DBBase, CatalogDB
+import urllib.parse
+from datetime import datetime, timezone
+from operator import attrgetter
+from pathlib import Path
+
+import django_filters
+from django.conf import settings
+from rest_framework import viewsets
+from rest_framework.authentication import (BasicAuthentication,
+                                           SessionAuthentication,
+                                           TokenAuthentication)
+from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
 from sqlalchemy.sql import text
+
+from tno.db import CatalogDB, DBBase
+from tno.models import Occultation
+from tno.occviz import visibility
+from tno.serializers import OccultationSerializer
+from tno.sora_map import sora_occultation_map
+from tno.tasks import create_occ_map_task
 
 
 class CharInFilter(django_filters.BaseInFilter, django_filters.CharFilter):
     pass
 
+
 class OccultationFilter(django_filters.FilterSet):
-    start_date = django_filters.DateTimeFilter(field_name='date_time',lookup_expr='gte')
-    end_date = django_filters.DateTimeFilter(field_name='date_time',lookup_expr='lte')
+    start_date = django_filters.DateTimeFilter(
+        field_name='date_time', lookup_expr='gte')
+    end_date = django_filters.DateTimeFilter(
+        field_name='date_time', lookup_expr='lte')
     min_mag = django_filters.NumberFilter(field_name='g', lookup_expr='gte')
     max_mag = django_filters.NumberFilter(field_name='g', lookup_expr='lte')
-    dynclass = django_filters.CharFilter(field_name='asteroid__dynclass', lookup_expr='iexact')
-    base_dynclass = django_filters.CharFilter(field_name='asteroid__base_dynclass', lookup_expr='iexact')
+    dynclass = django_filters.CharFilter(
+        field_name='asteroid__dynclass', lookup_expr='iexact')
+    base_dynclass = django_filters.CharFilter(
+        field_name='asteroid__base_dynclass', lookup_expr='iexact')
     name = CharInFilter(field_name='asteroid__name', lookup_expr='in')
-    asteroid_id = django_filters.NumberFilter(field_name='asteroid__id', lookup_expr='exact')
+    asteroid_id = django_filters.NumberFilter(
+        field_name='asteroid__id', lookup_expr='exact')
+
     class Meta:
         model = Occultation
-        fields = ['start_date','end_date', 'min_mag', 'max_mag', 'dynclass', 'base_dynclass', 'name', 'asteroid_id']
+        fields = ['start_date', 'end_date', 'min_mag', 'max_mag',
+                  'dynclass', 'base_dynclass', 'name', 'asteroid_id']
 
 
 class OccultationViewSet(viewsets.ReadOnlyModelViewSet):
@@ -48,16 +59,59 @@ class OccultationViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [AllowAny]
 
     queryset = Occultation.objects.all()
-    
+
     serializer_class = OccultationSerializer
 
     filterset_class = OccultationFilter
     filter_fields = ("id", "name", "number", "date_time")
     search_fields = ("name", "number")
 
-    ordering_fields = ("id", "name", "number", "date_time", "ra_star_candidate", "dec_star_candidate", "ra_target", " dec_target", "closest_approach", "position_angle", "velocity", "delta", "g", "j", "h", "k", "long", "loc_t", "off_ra", "off_dec", "proper_motion", "ct", "multiplicity_flag", "e_ra", "e_dec", "pmra", "pmdec", "ra_star_deg", "dec_star_deg", "ra_target_deg", "dec_target_deg", "created_at")
+    ordering_fields = ("id", "name", "number", "date_time", "ra_star_candidate", "dec_star_candidate", "ra_target", " dec_target", "closest_approach", "position_angle", "velocity", "delta", "g", "j", "h",
+                       "k", "long", "loc_t", "off_ra", "off_dec", "proper_motion", "ct", "multiplicity_flag", "e_ra", "e_dec", "pmra", "pmdec", "ra_star_deg", "dec_star_deg", "ra_target_deg", "dec_target_deg", "created_at")
     ordering = ("date_time",)
-    
+
+    @action(detail=True, methods=["get"], permission_classes=(AllowAny,))
+    def create_map(self, request, pk):
+        obj = self.get_object()
+
+        filepath = obj.get_map_filepath()
+
+        force = bool(request.query_params.get('force', False))
+        if force == True and filepath.exists():
+            filepath.unlink()
+
+        if not filepath.exists():
+            # TODO: Generate map with celery
+            sora_occultation_map(
+                name=obj.name,
+                diameter=obj.diameter,
+                ra_star_candidate=obj.ra_star_candidate,
+                dec_star_candidate=obj.dec_star_candidate,
+                date_time=obj.date_time,
+                closest_approach=obj.closest_approach,
+                position_angle=obj.position_angle,
+                velocity=obj.velocity,
+                delta=obj.delta,
+                g=obj.g,
+                long=obj.long,
+                filepath=filepath,
+                dpi=50
+            )
+
+        if filepath.exists():
+            return Response({
+                "url": request.build_absolute_uri(obj.get_map_relative_url()),
+                "occultation": obj.id,
+                "name": obj.name,
+                "date_time": obj.date_time.isoformat(),
+                "filename": filepath.name,
+                "filezise": filepath.stat().st_size,
+                "creation_time": datetime.fromtimestamp(
+                    filepath.stat().st_ctime).astimezone(timezone.utc).isoformat()
+            })
+        else:
+            # TODO: Retornar mensagem de erro
+            pass
 
     @action(detail=False, methods=["get"], permission_classes=(AllowAny,))
     def next_twenty(self, request):
@@ -69,42 +123,43 @@ class OccultationViewSet(viewsets.ReadOnlyModelViewSet):
         #     """
         paginator = PageNumberPagination()
         paginator.page_size = 10
-        lista = Occultation.objects.filter(date_time__gte=datetime.now()).order_by('date_time')[:20]
-        ordered = sorted(lista, key=attrgetter(request.query_params.get('ordering', '').replace('-', '')), reverse='-' in request.query_params.get('ordering', ''))
+        lista = Occultation.objects.filter(
+            date_time__gte=datetime.now()).order_by('date_time')[:20]
+        ordered = sorted(lista, key=attrgetter(request.query_params.get('ordering', '').replace(
+            '-', '')), reverse='-' in request.query_params.get('ordering', ''))
         result_page = paginator.paginate_queryset(ordered, request)
         serializer = OccultationSerializer(result_page, many=True)
         return paginator.get_paginated_response(serializer.data)
-    
 
     @action(detail=False, methods=["get"], permission_classes=(AllowAny,))
     def filter_location(self, request):
         queryset = Occultation.objects.all()
-        #date filter
+        # date filter
         start_date = self.request.query_params.get('start_date', None)
         end_date = self.request.query_params.get('end_date', None)
         if start_date and end_date:
-            queryset = queryset.filter(date_time__range=[start_date, end_date])  
+            queryset = queryset.filter(date_time__range=[start_date, end_date])
         elif start_date:
             queryset = queryset.filter(date_time__gte=start_date)
         elif end_date:
             queryset = queryset.filter(date_time__lte=end_date)
-        #magnitude filter
+        # magnitude filter
         min_mag = self.request.query_params.get('min_mag', None)
         max_mag = self.request.query_params.get('max_mag', None)
         if min_mag and max_mag:
             queryset = queryset.filter(g__range=[min_mag, max_mag])
-        #asteroid filter  (filter_type, filter_value)
-        if(self.request.query_params.get('filter_type', None) == "name"):
+        # asteroid filter  (filter_type, filter_value)
+        if (self.request.query_params.get('filter_type', None) == "name"):
             values = self.request.query_params.get('filter_value', None)
             names = values.split(';')
             queryset = queryset.filter(asteroid__name__in=names)
         elif (self.request.query_params.get('filter_type', None) == "dynclass"):
             dynclass = self.request.query_params.get('filter_value', None)
             queryset = queryset.filter(asteroid__dynclass=dynclass)
-        elif(self.request.query_params.get('filter_type', None) == "base_dynclass"):
+        elif (self.request.query_params.get('filter_type', None) == "base_dynclass"):
             basedyn = self.request.query_params.get('filter_value', None)
             queryset = queryset.filter(asteroid__base_dynclass=basedyn)
-        #geografic filter
+        # geografic filter
         latitude = self.request.query_params.get('lat', None)
         longitude = self.request.query_params.get('long', None)
         radius = self.request.query_params.get('radius', None)
@@ -118,39 +173,40 @@ class OccultationViewSet(viewsets.ReadOnlyModelViewSet):
                 if tempo_decorrido >= limite_tempo:
                     break
                 star_cordinates = item.ra_star_candidate + " " + item.dec_star_candidate
-                status, info = visibility(float(latitude), float(longitude), float(radius), item.date_time, star_cordinates, item.closest_approach, item.position_angle, item.velocity, item.delta, offset=(item.off_ra, item.off_dec)) 
-                if(status):
+                status, info = visibility(float(latitude), float(longitude), float(radius), item.date_time, star_cordinates,
+                                          item.closest_approach, item.position_angle, item.velocity, item.delta, offset=(item.off_ra, item.off_dec))
+                if (status):
                     visibles.append(item.id)
             queryset = queryset.filter(id__in=visibles)
-        #order
+        # order
         ordering = self.request.query_params.get('ordering', None)
         if ordering:
             queryset = queryset.order_by(ordering)
-        #return
-        paginator = PageNumberPagination() 
+        # return
+        paginator = PageNumberPagination()
         paginator.page_size = 10
         result_page = paginator.paginate_queryset(queryset, request)
         serializer = OccultationSerializer(result_page, many=True)
         return paginator.get_paginated_response(serializer.data)
 
     @action(detail=True, methods=["get"], permission_classes=(AllowAny,))
-    def get_star_by_event(self, request,pk=None):
+    def get_star_by_event(self, request, pk=None):
         pre_occ = self.get_object()
         ra = pre_occ.ra_star_deg
         dec = pre_occ.dec_star_deg
 
-        # TODO: No futuro vai ser necessário identificar qual o catalogo de estrela foi utilizado 
+        # TODO: No futuro vai ser necessário identificar qual o catalogo de estrela foi utilizado
         # nas predição, no momento todas as predições estão utilizando o gaia.DR2
         db = CatalogDB(pool=False)
         rows = db.radial_query(
             tablename="dr2",
             schema="gaia",
-            ra_property="ra", 
-            dec_property="dec", 
-            ra=float(ra), 
+            ra_property="ra",
+            dec_property="dec",
+            ra=float(ra),
             dec=float(dec),
             radius=0.001)
-        
+
         if len(rows) > 0:
             return Response(rows[0])
         return Response({})

--- a/frontend/src/components/OccultationTable/index.js
+++ b/frontend/src/components/OccultationTable/index.js
@@ -11,17 +11,17 @@ import styles from './style'
 function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
     const navigate = useNavigate()
     const defaultHiddenColumnNames = [
-        "number", 
-        "delta", 
-        "long", 
-        "loc_t", 
-        "off_ra", 
-        "off_dec", 
-        "proper_motion", 
-        "j", 
-        "h", 
-        "k", 
-        "ra_target", 
+        "number",
+        "delta",
+        "long",
+        "loc_t",
+        "off_ra",
+        "off_dec",
+        "proper_motion",
+        "j",
+        "h",
+        "k",
+        "ra_target",
         "dec_target",
         "ra_target_deg",
         "dec_target_deg",
@@ -40,41 +40,40 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
 
     useEffect(() => {
         setOccultationsTable(tableData);
-      }, [tableData])
+    }, [tableData])
 
     useEffect(() => {
         setOccultationsCount(totalCount);
-     }, [totalCount])
+    }, [totalCount])
 
-    
+
     const occultationsTableColumns = [
         {
-          name: 'index',
-          title: ' ',
-          width: 50,
-          sortingEnabled: false
+            name: 'index',
+            title: ' ',
+            width: 50,
+            sortingEnabled: false
         },
         {
-          name: 'detail',
-          title: publicPage?' ': 'Detail',
-          width: 80,
-          customElement: (row) => (
-            <Button className={classes.btnDetail} onClick={() => publicPage?window.open(row.detail, "_blank"):navigate(row.detail)}>
-              <InfoOutlinedIcon />
-            </Button>
-          ),
-          align: 'center',
-          sortingEnabled: false,
-          headerTooltip: 'Occultation Prediction Details'
+            name: 'detail',
+            title: publicPage ? ' ' : 'Detail',
+            width: 80,
+            customElement: (row) => (
+                <Button className={classes.btnDetail} onClick={() => publicPage ? window.open(row.detail, "_blank") : navigate(row.detail)}>
+                    <InfoOutlinedIcon />
+                </Button>
+            ),
+            align: 'center',
+            sortingEnabled: false,
+            headerTooltip: 'Occultation Prediction Details'
         },
         {
-            name: 'map',
+            name: 'map_url',
             title: 'Map',
             width: 150,
             align: 'center',
             headerTooltip: 'Occultation Map',
-            customElement: (row) => row.map?<img className={classes.imgThumb} src={row.map} />:<i>no map</i>
-            
+            customElement: (row) => row.map_url !== null ? <img className={classes.imgThumb} src={row.map_url} /> : <i>no map</i>
         },
         {
             name: 'name',
@@ -82,7 +81,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: 'Asteroid Name (Number)',
-            customElement: (row) => <span>{row.name + (row.number? ' (' +row.number + ')':'')}</span>
+            customElement: (row) => <span>{row.name + (row.number ? ' (' + row.number + ')' : '')}</span>
         },
         {
             name: 'number',
@@ -105,7 +104,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: 'Geocentric Closest Approach (arcsec)',
-            customElement: (row) => <span>{row.closest_approach?row.closest_approach.toFixed(3):''}</span>
+            customElement: (row) => <span>{row.closest_approach ? row.closest_approach.toFixed(3) : ''}</span>
         },
         {
             name: 'position_angle',
@@ -113,7 +112,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: 'Position Angle with respect to the star at closest approach (deg)',
-            customElement: (row) => <span>{row.position_angle?row.position_angle.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.position_angle ? row.position_angle.toFixed(2) : ''}</span>
         },
         {
             name: 'velocity',
@@ -121,7 +120,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: 'Velocity in the plane of the sky (positive is prograde, negative is retrograde) (Km/s)',
-            customElement: (row) => <span>{row.velocity?row.velocity.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.velocity ? row.velocity.toFixed(2) : ''}</span>
         },
         {
             name: 'delta',
@@ -129,7 +128,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: 'Geocentric Distance (AU)',
-            customElement: (row) => <span>{row.delta?row.delta.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.delta ? row.delta.toFixed(2) : ''}</span>
         },
         {
             name: 'long',
@@ -137,7 +136,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: 'East longitude of sub-planet point (positive towards East) (deg)',
-            customElement: (row) => <span>{row.long?row.long.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.long ? row.long.toFixed(2) : ''}</span>
         },
         {
             name: 'loc_t',
@@ -152,7 +151,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: 'Offset applied to ephemeris in RA (mas)',
-            customElement: (row) => <span>{row.off_ra?row.off_ra.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.off_ra ? row.off_ra.toFixed(2) : ''}</span>
         },
         {
             name: 'off_dec',
@@ -160,7 +159,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: 'Offset applied to ephemeris in DEC (mas)',
-            customElement: (row) => <span>{row.off_dec?row.off_dec.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.off_dec ? row.off_dec.toFixed(2) : ''}</span>
         },
         {
             name: 'proper_motion',
@@ -175,7 +174,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's G magnitude (mag)",
-            customElement: (row) => <span>{row.g?row.g.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.g ? row.g.toFixed(2) : ''}</span>
         },
         {
             name: 'j',
@@ -183,7 +182,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's J magnitude (mag)",
-            customElement: (row) => <span>{row.j?row.j.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.j ? row.j.toFixed(2) : ''}</span>
         },
         {
             name: 'h',
@@ -191,7 +190,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's H magnitude (mag)",
-            customElement: (row) => <span>{row.h?row.h.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.h ? row.h.toFixed(2) : ''}</span>
         },
         {
             name: 'k',
@@ -199,14 +198,14 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's K magnitude (mag)",
-            customElement: (row) => <span>{row.k?row.k.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.k ? row.k.toFixed(2) : ''}</span>
         },
         {
             name: 'ra_target',
             title: 'Object RA',
             width: 150,
             align: 'center',
-            headerTooltip:"Object's Right Ascension (hh mm ss.ssss)"
+            headerTooltip: "Object's Right Ascension (hh mm ss.ssss)"
         },
         {
             name: 'dec_target',
@@ -221,7 +220,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Object's Right Ascension (deg)",
-            customElement: (row) => <span>{row.ra_target_deg?row.ra_target_deg.toFixed(8):''}</span>
+            customElement: (row) => <span>{row.ra_target_deg ? row.ra_target_deg.toFixed(8) : ''}</span>
         },
         {
             name: 'dec_target_deg',
@@ -229,7 +228,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Object's Declination (deg)",
-            customElement: (row) => <span>{row.dec_target_deg?row.dec_target_deg.toFixed(8):''}</span>
+            customElement: (row) => <span>{row.dec_target_deg ? row.dec_target_deg.toFixed(8) : ''}</span>
         },
         {
             name: 'ra_star_candidate',
@@ -251,7 +250,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's Right Ascension (deg)",
-            customElement: (row) => <span>{row.ra_star_deg?row.ra_star_deg.toFixed(8):''}</span>
+            customElement: (row) => <span>{row.ra_star_deg ? row.ra_star_deg.toFixed(8) : ''}</span>
         },
         {
             name: 'dec_star_deg',
@@ -259,7 +258,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's Declination (deg)",
-            customElement: (row) => <span>{row.dec_star_deg?row.dec_star_deg.toFixed(8):''}</span>
+            customElement: (row) => <span>{row.dec_star_deg ? row.dec_star_deg.toFixed(8) : ''}</span>
         },
         {
             name: 'e_ra',
@@ -267,7 +266,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's RA uncertainty (mas)",
-            customElement: (row) => <span>{row.e_ra?row.e_ra.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.e_ra ? row.e_ra.toFixed(2) : ''}</span>
         },
         {
             name: 'e_dec',
@@ -275,7 +274,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's DEC uncertainty (mas)",
-            customElement: (row) => <span>{row.e_dec?row.e_dec.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.e_dec ? row.e_dec.toFixed(2) : ''}</span>
         },
         {
             name: 'pmra',
@@ -283,7 +282,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's proper motion in RA (mas/y)",
-            customElement: (row) => <span>{row.pmra?row.pmra.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.pmra ? row.pmra.toFixed(2) : ''}</span>
         },
         {
             name: 'pmdec',
@@ -291,7 +290,7 @@ function OccultationTable({ loadData, tableData, totalCount, publicPage }) {
             width: 150,
             align: 'center',
             headerTooltip: "Star's proper motion in DEC (mas/y)",
-            customElement: (row) => <span>{row.pmdec?row.pmdec.toFixed(2):''}</span>
+            customElement: (row) => <span>{row.pmdec ? row.pmdec.toFixed(2) : ''}</span>
         },
         {
             name: 'multiplicity_flag',

--- a/frontend/src/pages/Occultation/Detail.js
+++ b/frontend/src/pages/Occultation/Detail.js
@@ -13,11 +13,12 @@ import List from '../../components/List';
 import Aladin from '../../components/Aladin/index';
 import {
   getOccultationById,
-  getOccultationMap,
+  // getOccultationMap,
   getStarByOccultationId
 } from '../../services/api/Occultation';
 import useStyles from './styles'
 import { isNull } from 'lodash';
+import PredictOccultationMap from './partials/PredictMap';
 
 function OccultationDetail() {
   const { id } = useParams();
@@ -44,32 +45,32 @@ function OccultationDetail() {
     });
   }, [id]);
 
-  const createJsonOcc = (occ) =>{
-    return {'name': occ.name,
-    'radius': occ.diameter?occ.diameter:0,
-    'coord': occ.ra_star_candidate + " " + occ.dec_star_candidate, 
-    'time': new Date(occ.date_time).toISOString(), 
-    'ca': occ.closest_approach,
-    'pa': occ.position_angle,
-    'vel': occ.velocity,
-    'dist': occ.delta,
-    'mag': occ.g,
-    'longi': occ.long
-    }
-  }
+  // const createJsonOcc = (occ) =>{
+  //   return {'name': occ.name,
+  //   'radius': occ.diameter?occ.diameter:0,
+  //   'coord': occ.ra_star_candidate + " " + occ.dec_star_candidate, 
+  //   'time': new Date(occ.date_time).toISOString(), 
+  //   'ca': occ.closest_approach,
+  //   'pa': occ.position_angle,
+  //   'vel': occ.velocity,
+  //   'dist': occ.delta,
+  //   'mag': occ.g,
+  //   'longi': occ.long
+  //   }
+  // }
 
-  useEffect(() => {
-    if (occultation.date_time) {
-      const conteudo = createJsonOcc(occultation)
-      getOccultationMap(conteudo)
-        .then((res) => {
-        setMap(res.config.baseURL + res.config.url + '?name=' + encodeURI(occultation.name) + '&time=' + encodeURI(new Date(occultation.date_time).toISOString()));
-      },
-      ).catch((err) =>{
-        setErroMap(true);
-      });
-    }
-  }, [occultation])
+  // useEffect(() => {
+  //   if (occultation.date_time) {
+  //     const conteudo = createJsonOcc(occultation)
+  //     getOccultationMap(conteudo)
+  //       .then((res) => {
+  //       setMap(res.config.baseURL + res.config.url + '?name=' + encodeURI(occultation.name) + '&time=' + encodeURI(new Date(occultation.date_time).toISOString()));
+  //     },
+  //     ).catch((err) =>{
+  //       setErroMap(true);
+  //     });
+  //   }
+  // }, [occultation])
 
   useEffect(() => {
     setCircumstances([
@@ -107,30 +108,30 @@ function OccultationDetail() {
       {
         title: 'G* mag*',
         tooltip: 'Gaia magnitude corrected from velocity',
-        value: `${occultation.g_mag_vel_corrected?occultation.g_mag_vel_corrected.toFixed(3):null}`,
+        value: `${occultation.g_mag_vel_corrected ? occultation.g_mag_vel_corrected.toFixed(3) : null}`,
       },
       {
         title: 'RP* mag*',
         tooltip: 'Gaia RP magnitude corrected from velocity',
-        value: `${occultation.g_mag_vel_corrected?occultation.g_mag_vel_corrected.toFixed(3):null}`,
+        value: `${occultation.g_mag_vel_corrected ? occultation.g_mag_vel_corrected.toFixed(3) : null}`,
       },
       {
         title: 'H* mag*',
         tooltip: '2MASS H magnitude corrected from velocity',
-        value: `${occultation.h_mag_vel_corrected?occultation.h_mag_vel_corrected.toFixed(3):null}`,
+        value: `${occultation.h_mag_vel_corrected ? occultation.h_mag_vel_corrected.toFixed(3) : null}`,
       },
       {
         title: 'Magnitude Drop',
-        value: `${occultation.magnitude_drop?occultation.magnitude_drop.toFixed(3):null}`,
+        value: `${occultation.magnitude_drop ? occultation.magnitude_drop.toFixed(3) : null}`,
       },
       {
         title: 'Uncertainty in Time',
-        value: `${occultation.instant_uncertainty?occultation.instant_uncertainty.toFixed(1):null}`,
+        value: `${occultation.instant_uncertainty ? occultation.instant_uncertainty.toFixed(1) : null}`,
       },
       {
         title: 'Creation Date',
         tooltip: 'Date of the prediction\'s computation',
-        value: `${occultation.created_at?moment(occultation.created_at).utc() : null}`
+        value: `${occultation.created_at ? moment(occultation.created_at).utc() : null}`
       },
     ]);
 
@@ -146,7 +147,7 @@ function OccultationDetail() {
       },
       {
         title: 'Star astrometric position in catalogue (ICRF)',
-        value: `${starObj.ra?starObj.ra.toFixed(8):null} ${starObj.dec?starObj.dec.toFixed(7):null}`,
+        value: `${starObj.ra ? starObj.ra.toFixed(8) : null} ${starObj.dec ? starObj.dec.toFixed(7) : null}`,
       },
       {
         title: 'Star astrometric position with proper motion (ICRF)',
@@ -158,7 +159,7 @@ function OccultationDetail() {
       },
       {
         title: 'Proper motion',
-        value: `RA: ${starObj.pmra?starObj.pmra.toFixed(1):null} ±${starObj.pmra_error?starObj.pmra_error.toFixed(1):null}, Dec: ${starObj.pmdec?starObj.pmdec.toFixed(1):null} ±${starObj.pmdec_error?starObj.pmdec_error.toFixed(1):null} (mas/yr)`,
+        value: `RA: ${starObj.pmra ? starObj.pmra.toFixed(1) : null} ±${starObj.pmra_error ? starObj.pmra_error.toFixed(1) : null}, Dec: ${starObj.pmdec ? starObj.pmdec.toFixed(1) : null} ±${starObj.pmdec_error ? starObj.pmdec_error.toFixed(1) : null} (mas/yr)`,
       },
       {
         title: 'Source of proper motion',
@@ -166,38 +167,38 @@ function OccultationDetail() {
       },
       {
         title: 'Uncertainty in the star position',
-        value: `${starObj.ra_error?starObj.ra_error.toFixed(1):null} ${starObj.dec_error?starObj.dec_error.toFixed(1):null} (mas)`,
+        value: `${starObj.ra_error ? starObj.ra_error.toFixed(1) : null} ${starObj.dec_error ? starObj.dec_error.toFixed(1) : null} (mas)`,
       },
       {
         title: 'G magnitude',
-        value: `${starObj.phot_g_mean_mag?starObj.phot_g_mean_mag.toFixed(3):null}`,
+        value: `${starObj.phot_g_mean_mag ? starObj.phot_g_mean_mag.toFixed(3) : null}`,
       },
       {
         title: 'RP magnitude (source: GaiaDR2)',
-        value: `${starObj.phot_g_mean_mag?starObj.phot_g_mean_mag.toFixed(3):null}`,
+        value: `${starObj.phot_g_mean_mag ? starObj.phot_g_mean_mag.toFixed(3) : null}`,
       },
       {
         title: 'BP magnitude (source: GaiaDR2)',
-        value:  `${starObj.phot_bp_mean_mag?starObj.phot_bp_mean_mag.toFixed(3):null}`,
+        value: `${starObj.phot_bp_mean_mag ? starObj.phot_bp_mean_mag.toFixed(3) : null}`,
       },
       {
         title: 'J magnitude (source: 2MASS)',
-        value: `${occultation.j?occultation.j.toFixed(3):null}`,
+        value: `${occultation.j ? occultation.j.toFixed(3) : null}`,
       },
       {
         title: 'H magnitude (source: 2MASS)',
-        value: `${occultation.h?occultation.h.toFixed(3):null}`,
+        value: `${occultation.h ? occultation.h.toFixed(3) : null}`,
       },
       {
         title: 'K magnitude (source: 2MASS)',
-        value: `${occultation.k?occultation.k.toFixed(3):null}`,
+        value: `${occultation.k ? occultation.k.toFixed(3) : null}`,
       },
     ]);
 
     setObject([
       {
         title: 'Object',
-        value: `${occultation.name} ${occultation.number?'('+occultation.number +')' :'' }`,
+        value: `${occultation.name} ${occultation.number ? '(' + occultation.number + ')' : ''}`,
       },
       {
         title: 'Diameter',
@@ -259,28 +260,11 @@ function OccultationDetail() {
     <>
       <Grid container spacing={2}>
         <Grid item xs={12}>
-          <Card>
-            <CardHeader title="Occultation Prediction Map" />
-            <CardContent className={classes.divImg}>
-              { map && !erroMap &&
-                <img
-                  className={classes.mapImg}
-                  src={map}
-                  alt={occultation.name}
-                />
-              }
-              {!map && !erroMap &&
-                <CircularProgress
-                  className={classes.circularProgress}
-                  disableShrink
-                  size={50}
-                />
-              }
-              { erroMap &&
-                <span className={classes.erroMap}>An error occurred while generating the map.</span>
-              }
-            </CardContent>
-          </Card>
+          {occultation.id !== undefined && (
+            <PredictOccultationMap
+              occultationId={occultation.id}
+            />
+          )}
         </Grid>
       </Grid>
       <Grid container spacing={2}>

--- a/frontend/src/pages/Occultation/index.js
+++ b/frontend/src/pages/Occultation/index.js
@@ -69,7 +69,7 @@ function Occultation() {
             data.results.map((row) => ({
               key: row.id,
               detail: `/dashboard/occultation-detail/${row.id}`,
-              map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
+              // map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
               ...row
             }))
           )
@@ -98,7 +98,7 @@ function Occultation() {
             data.results.map((row) => ({
               key: row.id,
               detail: `/dashboard/occultation-detail/${row.id}`,
-              map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
+              // map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
               ...row
             }))
           )

--- a/frontend/src/pages/Occultation/partials/PredictMap.js
+++ b/frontend/src/pages/Occultation/partials/PredictMap.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Card from '@mui/material/Card'
+import CardHeader from '@mui/material/CardHeader'
+import CardContent from '@mui/material/CardContent'
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import Stack from '@mui/material/Stack';
+
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import RefreshIcon from '@mui/icons-material/Refresh';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+
+import Box from '@mui/material/Box'
+import { useQuery } from 'react-query'
+import { getOrCreatePredictionMap } from '../../../services/api/Occultation';
+import moment from 'moment';
+
+
+
+function PredictOccultationMap({ occultationId }) {
+
+  const [force, setForce] = React.useState(false)
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['getOrCreatePredrictMap', { id: occultationId, force: force }],
+    queryFn: getOrCreatePredictionMap,
+    keepPreviousData: false,
+    refetchInterval: false,
+    refetchOnmount: false,
+    refetchOnWindowFocus: false,
+    onSuccess: () => { if (force === true) setForce(false) },
+    staleTime: 1 * 60 * 1000,
+  })
+
+  const handleRefresh = () => {
+    if (force === true) return
+    if (isLoading === true) return
+    setForce(true)
+  }
+
+  return (
+    <Card>
+      <CardHeader
+        title="Occultation Prediction Map"
+        titleTypographyProps={{ variant: 'h6', fontSize: '1rem', }}
+        subheader={data !== undefined ? `Created ${moment(data.creation_time).fromNow()}` : ""}
+        subheaderTypographyProps={{ variant: 'subtitle1', fontSize: '0.8rem', }}
+        action={
+          <>
+            <IconButton
+              onClick={handleRefresh}
+              disabled={isLoading}
+            >
+              <RefreshIcon />
+            </IconButton>
+            <IconButton
+              href={data?.url}
+              target="_blank"
+              disabled={!data}
+            >
+              <OpenInNewIcon />
+            </IconButton>
+          </>
+        }
+      />
+      <CardContent
+        display="flex"
+        sx={{
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Box>
+          <Box
+            flex={1}
+            display="flex"
+            sx={{
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            {isLoading && (
+              <Box
+                display="flex"
+                minHeight={250}
+                alignItems="center"
+                justifyContent="center"
+                m="auto"
+                flexDirection="column"
+                alignSelf="center"
+                flex={1}
+              >
+                <CircularProgress color="secondary" />
+                <Typography variant="body2" mt={2}>
+                  Creating map. This request may take a few seconds.
+                </Typography>
+              </Box>
+            )}
+            {isError && (
+              <Stack sx={{ width: '100%' }}>
+                <Alert variant="outlined" severity="error">
+                  Sorry, map creation failed. Please try again and if the problem persists,
+                  let us know via the helpdesk
+                </Alert>
+              </Stack>
+            )}
+            {data !== undefined && (
+              <Box
+                component="img"
+                sx={{
+                  maxWidth: { xs: 400, sm: 450, md: 480, lg: 500, xl: 900 },
+                }}
+                alt=""
+                src={data.url}
+              />
+            )}
+          </Box>
+        </Box>
+      </CardContent>
+    </Card >
+  )
+}
+PredictOccultationMap.defaultProps = {
+
+}
+
+PredictOccultationMap.propTypes = {
+  occultationId: PropTypes.number.isRequired,
+};
+
+
+export default PredictOccultationMap;

--- a/frontend/src/pages/PublicPortal/Home/partials/ocultation/index.js
+++ b/frontend/src/pages/PublicPortal/Home/partials/ocultation/index.js
@@ -51,13 +51,13 @@ function PublicOcutation() {
 
   const loadData = ({ sorting, pageSize, currentPage }) => {
     const ordering = sorting[0].direction === 'desc' ? `-${sorting[0].columnName}` : sorting[0].columnName;
-    const start = (filterView == "userSelect" || filterView == "period") && dateStart ? new Date(dateStart).toISOString().slice(0, 10) + ' 00:00:00' : null;
-    const end = (filterView == "userSelect" || filterView == "period") && dateEnd ? new Date(dateEnd).toISOString().slice(0, 10) + ' 23:59:59' : null;
-    const type = filterView == "userSelect" && filterType.value ? filterType.value.toLowerCase().replaceAll(' ', '_') : null;
-    const value = filterView == "userSelect" && filterValue.value ? filterValue.value : null;
-    const minmag = filterView == "userSelect" ? magnitude[0] : null;
-    const maxmag = filterView == "userSelect" ? magnitude[1] : null;
-    if (filterView == "next") {
+    const start = (filterView === "userSelect" || filterView === "period") && dateStart ? new Date(dateStart).toISOString().slice(0, 10) + ' 00:00:00' : null;
+    const end = (filterView === "userSelect" || filterView === "period") && dateEnd ? new Date(dateEnd).toISOString().slice(0, 10) + ' 23:59:59' : null;
+    const type = filterView === "userSelect" && filterType.value ? filterType.value.toLowerCase().replaceAll(' ', '_') : null;
+    const value = filterView === "userSelect" && filterValue.value ? filterValue.value : null;
+    const minmag = filterView === "userSelect" ? magnitude[0] : null;
+    const maxmag = filterView === "userSelect" ? magnitude[1] : null;
+    if (filterView === "next") {
       getNextTwenty({
         page: currentPage + 1,
         pageSize,
@@ -67,7 +67,7 @@ function PublicOcutation() {
           res.results.map((row) => ({
             key: row.id,
             detail: `/occultation-detail/${row.id}`,
-            map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
+            // map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
             ...row
           }))
         )
@@ -99,7 +99,7 @@ function PublicOcutation() {
             data.results.map((row) => ({
               key: row.id,
               detail: `/occultation-detail/${row.id}`,
-              map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
+              // map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
               ...row
             }))
           )
@@ -128,7 +128,7 @@ function PublicOcutation() {
             data.results.map((row) => ({
               key: row.id,
               detail: `/occultation-detail/${row.id}`,
-              map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
+              //map: urlExists(getMapUrl(row)) ? getMapUrl(row) : '',
               ...row
             }))
           )
@@ -146,7 +146,7 @@ function PublicOcutation() {
   }, [filterView]);
 
   useEffect(() => {
-    if (!isMount && filterView == 'period') {
+    if (!isMount && filterView === 'period') {
       loadData({ sorting: [{ columnName: 'date_time', direction: 'asc' }], pageSize: 10, currentPage: 0 });
     }
   }, [dateStart, dateEnd]);
@@ -161,19 +161,19 @@ function PublicOcutation() {
       <br></br><br></br>
       <Grid container spacing={1} mt="3">
         <Grid item xs={6} className={classes.mouse} sm={3} onClick={() => setFilterView('period')}>
-          <div className={clsx(filterView == 'period' ? classes.selected : classes.celula)}>Period</div>
+          <div className={clsx(filterView === 'period' ? classes.selected : classes.celula)}>Period</div>
         </Grid>
         <Grid item xs={6} sm={3} className={classes.mouse} onClick={() => setFilterView('')}>
-          <div className={clsx(filterView == '' ? classes.selected : classes.celula)}>All events</div>
+          <div className={clsx(filterView === '' ? classes.selected : classes.celula)}>All events</div>
         </Grid>
         <Grid item xs={6} sm={3} className={classes.mouse} onClick={() => setFilterView('next')}>
-          <div className={clsx(filterView == 'next' ? classes.selected : classes.celula)}>Next 20 events</div>
+          <div className={clsx(filterView === 'next' ? classes.selected : classes.celula)}>Next 20 events</div>
         </Grid>
         <Grid item xs={6} sm={3} className={classes.mouse} onClick={() => setFilterView('userSelect')}>
-          <div className={clsx(filterView == 'userSelect' ? classes.selected : classes.celula)}>User Selected</div>
+          <div className={clsx(filterView === 'userSelect' ? classes.selected : classes.celula)}>User Selected</div>
         </Grid>
       </Grid>
-      {filterView == 'period' &&
+      {filterView === 'period' &&
         <><br></br><Grid container spacing={2}>
           <Grid item xs={12}>
             <Card>
@@ -205,7 +205,7 @@ function PublicOcutation() {
           </Grid>
         </Grid></>
       }
-      {filterView == 'userSelect' &&
+      {filterView === 'userSelect' &&
         <><br></br>
           <OccultationFilter
             dateStart={dateStart}

--- a/frontend/src/pages/PublicPortal/Home/partials/ocultation/index.js
+++ b/frontend/src/pages/PublicPortal/Home/partials/ocultation/index.js
@@ -45,9 +45,9 @@ function PublicOcutation() {
       return false;
   }
 
-  function getMapUrl(occultation) {
-    return process.env.REACT_APP_SORA + '/map?name=' + encodeURI(occultation.name) + '&time=' + encodeURI(new Date(occultation.date_time).toISOString())
-  }
+  // function getMapUrl(occultation) {
+  //   return process.env.REACT_APP_SORA + '/map?name=' + encodeURI(occultation.name) + '&time=' + encodeURI(new Date(occultation.date_time).toISOString())
+  // }
 
   const loadData = ({ sorting, pageSize, currentPage }) => {
     const ordering = sorting[0].direction === 'desc' ? `-${sorting[0].columnName}` : sorting[0].columnName;

--- a/frontend/src/services/api/Occultation.js
+++ b/frontend/src/services/api/Occultation.js
@@ -49,8 +49,12 @@ export const getNextTwenty = ({ page, pageSize, ordering}) => {
 
 export const getStarByOccultationId = ({ id }) => api.get(`/occultations/${id}/get_star_by_event`).then((res) => res.data)
 
-export const getOccultationMap = (json) => {
-  return sora.post('/map', json);
+export const getOrCreatePredictionMap = ({ queryKey }) => {
+  const [_, params] = queryKey
+  const { id, force } = params
+  if (!id) { return }
+
+  return api.get(`/occultations/${id}/get_or_create_map`, { params: { force: force } }).then(res => res.data)
 }
 
 


### PR DESCRIPTION
Foi Criado um endpoint que permita criar (caso não exista) os mapas de predição para um evento especifico.
A criação do mapa é feita em tempo de execução durante a propria requisição.
Em caso de sucesso retorna um json contendo a URL do mapa gerado.
Caso o mapa já exista é retornado a url sem a criação de um novo mapa.
Permiti sobrescrever um mapa já existente. usando parametro "force=true".

No Frontend:
Ao acessar a interface de detalhe de uma occultação, verifica se o atributo map_url do evento de occultação é Null ou uma url.
Caso seja Null, faz uma requisição get para o endpoint solicitando a criação da imagem. e ao receber o retorno exibe a imagem.
Caso seja a url, apresenta a imagem direto.
Exibe a informação de quando o mapa foi criado.
Permite recriar o mapa usando o botão "Refresh" no header. 
Permeite abrir a imagem em uma nova aba.

Exemplo de requisições:
http://localhost/api/occultations/366937/create_map/
http://localhost/api/occultations/366937/create_map/?force=true

Exemplo do retorno:

{
    "url": "http://localhost/data/tmp/maps/Chiron_20230914_095352.jpg",
    "occultation": 366937,
    "name": "Chiron",
    "date_time": "2023-09-14T09:53:52+00:00",
    "filename": "Chiron_20230914_095352.jpg",
    "filezise": 55447,
    "creation_time": "2023-09-26T18:51:35.305206+00:00"
}
url - Url completa para o arquivo de mapa.
occultation - ID do evento de occultaçaõ
name - Asteroid Name
date_time - Data e hora do evento de ocultação
filename - Nome do arquivo de mapa formado pelo nome do asteroid e date_time tratando caracteres especias
filezise - Tamanho do arquivo de mapa em bytes
creation_time - Data de criação do arquivo, lido direto dos metadados do arquivo de imagem.
![mapa_ok](https://github.com/linea-it/tno/assets/1728977/94f58cff-6f2c-438c-8232-b15a1a473489)
![mapa_loading](https://github.com/linea-it/tno/assets/1728977/6bfe8b2a-7273-41f0-86c2-344b7344b981)
![mapa_falhou](https://github.com/linea-it/tno/assets/1728977/5bfe78a3-cdff-483b-bedc-3a19ad3035aa)
