### PR TITLE
Reorganizar os cards

### DIFF
--- a/frontend/src/pages/Occultation/Detail.js
+++ b/frontend/src/pages/Occultation/Detail.js
@@ -292,7 +292,7 @@ function OccultationDetail() {
         </Grid>
         {occultation.ra_star_candidate && occultation.dec_star_candidate ? (
           <Grid item xs={12} md={6}>
-            <Card>
+            {/* <Card>
               <CardHeader title="Sky map (Aladin)" />
               <CardContent>
                 <Aladin
@@ -300,7 +300,7 @@ function OccultationDetail() {
                   dec={occultation.dec_star_candidate}
                 />
               </CardContent>
-            </Card>
+            </Card> */}
           </Grid>
         ) : null}
       </Grid>

--- a/frontend/src/pages/Occultation/Detail.js
+++ b/frontend/src/pages/Occultation/Detail.js
@@ -255,15 +255,6 @@ function OccultationDetail() {
   return (
     <>
       <Grid container spacing={2}>
-        <Grid item xs={12}>
-          {occultation.id !== undefined && (
-            <PredictOccultationMap
-              occultationId={occultation.id}
-            />
-          )}
-        </Grid>
-      </Grid>
-      <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
           <Card>
             <CardHeader title="Occultation Prediction Circumstances" />
@@ -272,6 +263,13 @@ function OccultationDetail() {
             </CardContent>
           </Card>
         </Grid>
+        {occultation.id !== undefined && (
+          <Grid item xs={12} md={6}>
+            <PredictOccultationMap 
+            occultationId={occultation.id}
+             />
+          </Grid>
+        )}
         <Grid item xs={12} md={6}>
           <Card>
             <CardHeader title="Occulted Star" />
@@ -280,8 +278,6 @@ function OccultationDetail() {
             </CardContent>
           </Card>
         </Grid>
-      </Grid>
-      <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
           <Card>
             <CardHeader title="Object" />
@@ -290,8 +286,10 @@ function OccultationDetail() {
             </CardContent>
           </Card>
         </Grid>
-        {occultation.ra_star_candidate && occultation.dec_star_candidate ? (
-          <Grid item xs={12} md={6}>
+      </Grid>
+
+        {/* {occultation.ra_star_candidate && occultation.dec_star_candidate ? ( */}
+          {/* // <Grid item xs={12} md={6}> */}
             {/* <Card>
               <CardHeader title="Sky map (Aladin)" />
               <CardContent>
@@ -301,9 +299,9 @@ function OccultationDetail() {
                 />
               </CardContent>
             </Card> */}
-          </Grid>
-        ) : null}
-      </Grid>
+          {/* </Grid> */}
+        {/* ) : null} */}
+      {/* </Grid> */}
     </>
   );
 }

--- a/frontend/src/pages/Occultation/partials/PredictMap.js
+++ b/frontend/src/pages/Occultation/partials/PredictMap.js
@@ -110,7 +110,8 @@ function PredictOccultationMap({ occultationId }) {
               <Box
                 component="img"
                 sx={{
-                  maxWidth: { xs: 400, sm: 450, md: 480, lg: 500, xl: 900 },
+                  maxWidth: '100%',
+                  height: 'auto',
                 }}
                 alt=""
                 src={data.url}

--- a/frontend/src/routes/index.js
+++ b/frontend/src/routes/index.js
@@ -34,7 +34,6 @@ import PublicAboutUs from '../pages/PublicPortal/AboutUs/index'
 import PublicTutorials from '../pages/PublicPortal/Contact/index'
 import PublicOccultation from '../pages/PublicPortal/documentation/index'
 import OccultationDetail from '../pages/Occultation/Detail'
-import PublicSupporters from '../pages/PublicPortal/Home/partials/Supporters/index'
 import PublicBanner from '../components/PublicPortal/Banner/index'
 import PublicDocumentation from '../pages/PublicPortal/documentation/index'
 import PublicContact from '../pages/PublicPortal/Contact/index'
@@ -101,7 +100,6 @@ export default function AppRoutes() {
                 <div className={classes.titleItem}><label>Occultation Prediction Details</label></div>
               </Grid><br></br>
               <OccultationDetail />
-              <PublicSupporters />
             </div>
           </PublicPortalPage>
         }


### PR DESCRIPTION
This PR includes the following changes:

1. Removed duplicate footer line 'linea supported by'.
2. Hidden the 'Sky map (Aladin)' section.
3. Reorganized the cards as per the agreed-upon layout.
4. Corrected the size of the image rendered on the map.