### PR TITLE
781 fix jpl bsp downloads failing

### DIFF
--- a/pipelines/predict_occultation/parsl_config.py
+++ b/pipelines/predict_occultation/parsl_config.py
@@ -48,7 +48,7 @@ def get_config(key):
         "local": HighThroughputExecutor(
             label="local",
             worker_debug=False,
-            max_workers=8,
+            max_workers=4,
             provider=LocalProvider(
                 min_blocks=1,
                 init_blocks=1,

--- a/pipelines/predict_occultation/parsl_config.py
+++ b/pipelines/predict_occultation/parsl_config.py
@@ -48,7 +48,7 @@ def get_config(key):
         "local": HighThroughputExecutor(
             label="local",
             worker_debug=False,
-            max_workers=4,
+            max_workers=8,
             provider=LocalProvider(
                 min_blocks=1,
                 init_blocks=1,

--- a/pipelines/src/env.sh
+++ b/pipelines/src/env.sh
@@ -4,6 +4,6 @@ conda activate py3
 
 export PYTHONPATH=${PYTHONPATH}:${PIPELINE_ROOT}:${PIPELINE_PATH}:${PIPELINE_PREDIC_OCC}
 
-#ulimit -s 100000
-#ulimit -u 100000
+ulimit -s 100000
+ulimit -u 100000
 umask 0002

--- a/pipelines/src/env.sh
+++ b/pipelines/src/env.sh
@@ -4,6 +4,6 @@ conda activate py3
 
 export PYTHONPATH=${PYTHONPATH}:${PIPELINE_ROOT}:${PIPELINE_PATH}:${PIPELINE_PREDIC_OCC}
 
-ulimit -s 100000
-ulimit -u 100000
+#ulimit -s 100000
+#ulimit -u 100000
 umask 0002


### PR DESCRIPTION
Foram modificado o parâmetro COMMAND usado na url que obtem o bsp do jpl. A função primeiramente testa pela designação de asteroides e cometas. Se não encontrar, tenta buscar por corpos principais (por exemplo, Ceres, que é um planeta anão) e encontrando, retorna o bsp do corpo principal. Portanto, a atualização não retorna nada relativo a satélites naturais.