### PR TITLE
838 enhance poor asteroid download information handling

### DIFF
--- a/predict_occultation/src/asteroid/jpl.py
+++ b/predict_occultation/src/asteroid/jpl.py
@@ -1,4 +1,5 @@
 import base64
+import http
 import json
 import pathlib
 import shutil
@@ -72,7 +73,13 @@ def get_bsp_from_jpl(identifier, initial_date, final_date, directory, filename):
         "START_TIME": date1.strftime("%Y-%b-%d"),
         "STOP_TIME": date2.strftime("%Y-%b-%d"),
     }
+
     r = requests.get(urlJPL, params=parameters, stream=True)
+
+    if r.status_code != 200:
+        raise Exception(
+            f"Code {r.status_code} - {http.HTTPStatus(r.status_code).phrase}"
+        )
 
     # now we will check if there was a match in the results if not it will search other minor planets suche as Ceres, Makemake...
     if "No matches found." in json.loads(r.text)["result"]:

--- a/predict_occultation/src/run_pred_occ.py
+++ b/predict_occultation/src/run_pred_occ.py
@@ -802,8 +802,10 @@ def submit_tasks(jobid: int):
                 continue
 
             # ORBITAL ELEMENTS ----------------------------------------------
+            # Use ignore=False ou omita para que aos elementos orbitais sejam baixados.
+            # have_orb_ele = a.check_orbital_elements(days_to_expire=ORBITAL_ELEMENTS_DAYS_TO_EXPIRE)
             have_orb_ele = a.check_orbital_elements(
-                days_to_expire=ORBITAL_ELEMENTS_DAYS_TO_EXPIRE
+                days_to_expire=ORBITAL_ELEMENTS_DAYS_TO_EXPIRE, ignore=True
             )
 
             if have_orb_ele is False:


### PR DESCRIPTION
Fixed an issue where JPL outage messages were missing, ensuring comprehensive error messaging for improved user experience.

Updated the default pipeline to convey BSP JPL outage messages, enhancing error handling and making error messages more informative.

Removed the dependency on AstDys and MPC orbital elements download, streamlining the process and improving overall efficiency.