### PR TITLE
949 modificar a layer do aladin sky atlas

### DIFF
--- a/frontend/src/components/AladinV3/index.js
+++ b/frontend/src/components/AladinV3/index.js
@@ -47,7 +47,7 @@ export default class AladinV3 extends React.Component {
         survey: 'P/allWISE/color', // set initial image survey
         // survey: 'P/DSS2/color', // set initial image survey
         projection: 'SIN', // set a projection
-        fov: 0.1, // initial field of view in degrees
+        fov: 0.12, // initial field of view in degrees
         // target: 'NGC 2175', // initial target
         cooFrame: 'ICRS', // set galactic frame reticleColor: '#ff89ff', // change reticle color
         showReticle: false,

--- a/frontend/src/components/AladinV3/index.js
+++ b/frontend/src/components/AladinV3/index.js
@@ -47,7 +47,7 @@ export default class AladinV3 extends React.Component {
         survey: 'P/allWISE/color', // set initial image survey
         // survey: 'P/DSS2/color', // set initial image survey
         projection: 'SIN', // set a projection
-        fov: 0.5, // initial field of view in degrees
+        fov: 0.1, // initial field of view in degrees
         // target: 'NGC 2175', // initial target
         cooFrame: 'ICRS', // set galactic frame reticleColor: '#ff89ff', // change reticle color
         showReticle: false,


### PR DESCRIPTION
Modifica o FOV do campo do Aladin para 7 minutos.

A layer não foi modificada pois a survey solicitado não cobre 100% do ceu, tendo sido mantida a layer padrão.