### PR TITLE
Closed #1095 - improve home initial loading

### DIFF
--- a/backend/coreAdmin/settings.py
+++ b/backend/coreAdmin/settings.py
@@ -340,6 +340,16 @@ SPECTACULAR_SETTINGS = {
 # Skybot da Franca: SKYBOT_SERVER="http://vo.imcce.fr/webservices/skybot/"
 SKYBOT_SERVER = "http://vo.imcce.fr/webservices/skybot/"
 
+# Memcached
+CACHE_HOST = os.environ.get("CACHE_HOST", "memcached")
+CACHE_PORT = os.environ.get("CACHE_PORT", 11211)
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+        "LOCATION": f"{CACHE_HOST}:{CACHE_PORT}",
+    }
+}
+
 # CELERY_BROKER_URL = os.getenv(
 #     "CELERY_BROKER_URL", "amqp://tno:adminadmin@rabbit:5672/tno_vhost"
 # )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -66,6 +66,7 @@ prometheus-client==0.16.0
 psycopg2-binary==2.9.5
 pycparser==2.21
 pyerfa==2.0.0.1
+pymemcache==4.0.0
 pykdtree==1.3.9
 pyparsing==3.0.9
 pyproj==3.6.1

--- a/compose/local/docker-compose-template.yml
+++ b/compose/local/docker-compose-template.yml
@@ -145,6 +145,12 @@ services:
   mailhog:
     image: mailhog/mailhog:v1.0.0
 
+  memcached:
+    image: bitnami/memcached
+    environment:
+      - MEMCACHED_CACHE_SIZE=128
+      - MEMCACHED_THREADS=4
+      - MEMCACHED_MAX_ITEM_SIZE=8388608
 
   # https://medium.com/testing-with-cypress/running-cypress-tests-in-docker-containers-using-different-docker-images-2dee3450881e
   # cypress:

--- a/compose/production/docker-compose-template.yml
+++ b/compose/production/docker-compose-template.yml
@@ -93,3 +93,11 @@ services:
       - .env
     volumes:
       - rabbitmq-data:/var/lib/rabbitmq/
+  # Memory Cache: Memcached
+  # Documentation: https://hub.docker.com/r/bitnami/memcached
+  memcached:
+    image: bitnami/memcached
+    environment:
+      - MEMCACHED_CACHE_SIZE=128
+      - MEMCACHED_THREADS=4
+      - MEMCACHED_MAX_ITEM_SIZE=8388608

--- a/compose/testing/docker-compose-template.yml
+++ b/compose/testing/docker-compose-template.yml
@@ -95,3 +95,12 @@ services:
       RABBITMQ_DEFAULT_VHOST: ${RABBITMQ_DEFAULT_VHOST:-tno_vhost}
     volumes:
       - rabbitmq-data:/var/lib/rabbitmq/
+
+  # Memory Cache: Memcached
+  # Documentation: https://hub.docker.com/r/bitnami/memcached
+  memcached:
+    image: bitnami/memcached
+    environment:
+      - MEMCACHED_CACHE_SIZE=128
+      - MEMCACHED_THREADS=4
+      - MEMCACHED_MAX_ITEM_SIZE=8388608

--- a/frontend/src/contexts/PredictionContext.js
+++ b/frontend/src/contexts/PredictionContext.js
@@ -16,8 +16,8 @@ export function PredictionEventsProvider({ children }) {
       filters: {
         dt_after_local: dayjs(),
         date_time_after: dayjs().utc().format(),
-        dt_before_local: null,
-        date_time_before: null,
+        dt_before_local: dayjs().add(1, 'month'),
+        date_time_before: dayjs().utc().add(1, 'month').format(),
         filterType: '',
         filterValue: undefined,
         maginitudeMax: 15,


### PR DESCRIPTION
Foi adicionado um novo serviço "Memcached" para que algumas requisições possam ser respondidas sem a necessidade de executar a query. 

Os 2 endpoints (base_dynclass_with_prediction, dynclass_with_prediction) agora estão usando o cache em memoria, defini o cache time para 24h. A cada 24h uma das consultas vai levar o mesmo tempo que está hoje ~12s mas as demais serão quase instantaneas milesimos. 

Alterei o filtro default na home para um mes a frente, desta forma a lista de eventos carrega mais rápido. 

É necessário adicionar um novo serviço no docker-compose local dos dev, e fazer o build do backend. 

```yml
  # Memory Cache: Memcached
  # Documentation: https://hub.docker.com/r/bitnami/memcached
  memcached:
    image: bitnami/memcached
    environment:
      - MEMCACHED_CACHE_SIZE=128
      - MEMCACHED_THREADS=4
      - MEMCACHED_MAX_ITEM_SIZE=8388608
```

Closed #1095