### PR TITLE
Implementa filas separadas no Celery

### DIFF
--- a/backend/coreAdmin/celery.py
+++ b/backend/coreAdmin/celery.py
@@ -34,6 +34,7 @@ app.conf.beat_schedule = {
     "garbage-collector-every-three-hours": {
         "task": "tno.tasks.garbage_collector",
         "schedule": crontab(minute=0, hour="*/3"),
+        "options": {"queue": "maintenance"},
         # 'schedule': 30.0
     },
     # "prediction-map-every-30-minutes": {
@@ -43,10 +44,11 @@ app.conf.beat_schedule = {
     #     "schedule": crontab(minute="*/30"),
     # },
     # Executes every Monday morning at 2:00 a.m.
-    # "update_asteroid_table-every-monday": {
-    #     "task": "tno.tasks.update_asteroid_table",
-    #     "schedule": crontab(hour=2, minute=0, day_of_week=1),
-    # },
+    "update_asteroid_table-every-monday": {
+        "task": "tno.tasks.update_asteroid_table",
+        "schedule": crontab(hour=2, minute=0, day_of_week=1),
+        "options": {"queue": "maintenance"},
+    },
     # Executes every Day at 5:00 a.m.
     # "predict_job_for_updated_asteroids": {
     #     "task": "tno.tasks.predict_jobs_by_updated_asteroids",
@@ -62,26 +64,31 @@ app.conf.beat_schedule = {
         "task": "tno.tasks.run_subscription_filter_and_send_mail",
         "schedule": crontab(hour=9, minute=0),
         "kwargs": {"force_run": False},  # Set to True if needed
+        "options": {"queue": "scheduled"},
     },
     # Update occultation highlights daily at 00:00 UTC
     "update_occultations_highlights": {
         "task": "tno.tasks.update_occultations_highlights",
         "schedule": crontab(hour=0, minute=0),
+        "options": {"queue": "scheduled"},
     },
     # Update Unique Asteroid cache table every 6 hours
     "update_unique_asteroid_cache": {
         "task": "tno.tasks.update_unique_asteroids",
         "schedule": crontab(hour="*/6", minute=0),
+        "options": {"queue": "scheduled"},
     },
     # Update Unique Dynclass cache table every 6:15 hours
     "update_unique_dynclass_cache": {
         "task": "tno.tasks.update_unique_dynclass",
         "schedule": crontab(hour="*/6", minute=15),
+        "options": {"queue": "scheduled"},
     },
     # Update asteroid class cache memcached every 3 hours
     "update_asteroid_classes_cache": {
         "task": "tno.tasks.update_asteroid_classes_cache",
         "schedule": crontab(hour="*/3", minute=0),
+        "options": {"queue": "scheduled"},
     },
 }
 app.conf.timezone = "UTC"

--- a/backend/coreAdmin/settings.py
+++ b/backend/coreAdmin/settings.py
@@ -397,7 +397,7 @@ CELERY_QUEUES = (
         "maintenance",
         Exchange("maintenance"),
         routing_key="maintenance",
-        queue_arguments={"x-max-priority": 8},
+        queue_arguments={"x-max-priority": 7},
     ),
     Queue(
         "user-requested",

--- a/backend/coreAdmin/settings.py
+++ b/backend/coreAdmin/settings.py
@@ -15,6 +15,7 @@ import urllib.parse
 from pathlib import Path
 
 import environ
+from kombu import Exchange, Queue
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -371,6 +372,41 @@ CACHES = {
 # CELERY_RESULT_BACKEND = "django-db"
 
 # Celery
+# settings.py – you still need to declare the queues
+
+CELERY_QUEUES = (
+    Queue(
+        "default",
+        Exchange("default"),
+        routing_key="default",
+        queue_arguments={"x-max-priority": 5},
+    ),
+    Queue(
+        "thumbnails",
+        Exchange("thumbnails"),
+        routing_key="thumbnails",
+        queue_arguments={"x-max-priority": 2},
+    ),
+    Queue(
+        "scheduled",
+        Exchange("scheduled"),
+        routing_key="scheduled",
+        queue_arguments={"x-max-priority": 8},
+    ),
+    Queue(
+        "maintenance",
+        Exchange("maintenance"),
+        routing_key="maintenance",
+        queue_arguments={"x-max-priority": 8},
+    ),
+    Queue(
+        "user-requested",
+        Exchange("user-requested"),
+        routing_key="user-requested",
+        queue_arguments={"x-max-priority": 10},
+    ),
+)
+
 # ------------------------------------------------------------------------------
 if USE_TZ:
     # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-timezone
@@ -395,10 +431,10 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-time-limit
 # TODO: set to whatever value is adequate in your circumstances
-CELERY_TASK_TIME_LIMIT = 600
+CELERY_TASK_TIME_LIMIT = 7300
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-soft-time-limit
 # TODO: set to whatever value is adequate in your circumstances
-CELERY_TASK_SOFT_TIME_LIMIT = 580
+CELERY_TASK_SOFT_TIME_LIMIT = 7200
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-scheduler
 # CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-send-task-events

--- a/backend/start_worker.sh
+++ b/backend/start_worker.sh
@@ -15,4 +15,4 @@ celery -A coreAdmin worker \
     -l INFO \
     --pidfile="/tmp/%n.pid" \
     --logfile="/logs/%n%I.log" \
-    --queues=default,maintenance,scheduled,thumbnails  # Add all queues here
+    --queues=default,maintenance,scheduled,thumbnails,user-requested  # Add all queues here

--- a/backend/start_worker.sh
+++ b/backend/start_worker.sh
@@ -4,12 +4,15 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-echo "Starting Celery Worker"
+echo "Starting Celery Worker to listen to all queues..."
+
+# Remove any existing Celery PID files
 rm -f '/tmp/celery*.pid'
 rm -f '/tmp/celery.pid'
+
+# Start the Celery worker with all queues specified
 celery -A coreAdmin worker \
     -l INFO \
     --pidfile="/tmp/%n.pid" \
-    --logfile="/logs/%n%I.log"
-
-# --concurrency=1 \
+    --logfile="/logs/%n%I.log" \
+    --queues=default,maintenance,scheduled,thumbnails  # Add all queues here

--- a/backend/tno/management/commands/create_thumbnail_maps.py
+++ b/backend/tno/management/commands/create_thumbnail_maps.py
@@ -41,5 +41,5 @@ class Command(BaseCommand):
         job = group(header)
         job.link_error(prediction_maps_log_error.s())
 
-        results = job.apply_async()
+        results = job.apply_async(queue="thumbnails")
         self.stdout.write(f"All [{len(results)}] subtasks are submitted.")

--- a/backend/tno/tasks.py
+++ b/backend/tno/tasks.py
@@ -53,7 +53,7 @@ def teste_api_task():
     return True
 
 
-@shared_task
+@shared_task(queue="maintenance", soft_time_limit=7200, time_limit=10800)
 def garbage_collector():
     """Executado a cada 3 horas
     OBS: esta função não é exclusiva para os mapas.
@@ -75,7 +75,7 @@ def predict_jobs_for_upper_end_update(**kwargs):
         run_predicition_for_upper_end_update(debug=False)
 
 
-@shared_task
+@shared_task(queue="user-requested", soft_time_limit=900, time_limit=1800)
 def create_occ_map_task(**kwargs):
     sora_occultation_map(**kwargs)
 
@@ -86,7 +86,7 @@ def prediction_maps_log_error(request, exc, traceback):
     logger.error(f"{request.id} {exc} {traceback}")
 
 
-@shared_task
+@shared_task(queue="thumbnails", soft_time_limit=900, time_limit=1800)
 def create_thumbnail_maps():
     logger = logging.getLogger("predict_maps")
     logger.info("Starting create_thumbnail_maps task")
@@ -215,7 +215,7 @@ def assync_visibility_from_coeff(event_id, result_file, **kwargs):
     return event_id, bool(is_visible)
 
 
-@shared_task(soft_time_limit=7200, time_limit=10800)
+@shared_task(queue="maintenance", soft_time_limit=7200, time_limit=10800)
 def update_asteroid_table():
     """Updates the asteroid table data using data downloaded from MPC."""
     from tno.asteroid_table.asteroid_table_manager import AsteroidTableManager
@@ -259,7 +259,7 @@ def send_mail_subscription_task():
         raise
 
 
-@shared_task
+@shared_task(queue="scheduled", soft_time_limit=10800, time_limit=14400)
 def run_subscription_filter_and_send_mail(force_run=False):
     """
     Chains run_filter_task and send_mail_task to run sequentially.
@@ -282,7 +282,7 @@ def run_subscription_filter_and_send_mail(force_run=False):
         raise
 
 
-@shared_task
+@shared_task(queue="scheduled", soft_time_limit=7200, time_limit=10800)
 def update_asteroid_classes_cache():
 
     update_base_dynclass_cache()
@@ -313,7 +313,7 @@ def update_dynclass_cache():
     return None
 
 
-@shared_task
+@shared_task(queue="scheduled", soft_time_limit=7200, time_limit=10800)
 def update_occultations_highlights():
 
     logger = logging.getLogger("occultation_highlights")
@@ -390,7 +390,7 @@ def update_occultations_highlights():
     return highlights.id
 
 
-@shared_task
+@shared_task(queue="scheduled", soft_time_limit=7200, time_limit=10800)
 def update_unique_asteroids():
 
     logger = logging.getLogger("asteroid_cache")
@@ -462,7 +462,7 @@ def update_unique_asteroids():
     return current_count
 
 
-@shared_task
+@shared_task(queue="scheduled", soft_time_limit=7200, time_limit=10800)
 def update_unique_dynclass():
 
     logger = logging.getLogger("asteroid_cache")

--- a/frontend/src/contexts/PredictionContext.js
+++ b/frontend/src/contexts/PredictionContext.js
@@ -28,7 +28,7 @@ export function PredictionEventsProvider({ children }) {
         maginitudeDropMin: undefined,
         diameterMin: undefined,
         diameterMax: undefined,
-        closestApproachUncertainty: 500,
+        closestApproachUncertainty: undefined,
         eventDurationMin: undefined,
         geo: false,
         latitude: undefined,


### PR DESCRIPTION
**Problema**

* Tarefas agendadas eram penalizadas durante a geração de thumbnails.
* Falhas ocorriam antes da conclusão devido ao soft time limit curto. Correções anteriores não consideravam o hard time limit.

**Soluções implementadas**

* Criação de filas dedicadas: `default`, `thumbnails`, `scheduled`, `maintenance` e `user-requested`.
* Definido soft time limit mínimo de 2h e hard time limit com margem extra de 100s.
* Organização das tarefas:

  * `maintenance`: garbage collection, atualização de tabelas de asteroides.
  * `scheduled`: envios de e-mail, atualizações periódicas de cache.
  * `thumbnails`: geração de thumbnails.
  * `user-requested`: solicitações do usuário (ex: mapas SORA), com prioridade máxima.

**Prioridade das filas**
`thumbnails` < `default` < `maintenance` < `scheduled` < `user-requested`