### PR TITLE
Upgrade SPICE library to 64-bit for GFortran compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,15 +17,15 @@
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {},
-    // "ghcr.io/devcontainers-contrib/features/black:2": {},
-    // "ghcr.io/devcontainers-contrib/features/coverage-py:2": {},
-    // "ghcr.io/devcontainers-contrib/features/isort:2": {},
-    "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
-    "ghcr.io/devcontainers-contrib/features/zsh-plugins:0": {},
+    "ghcr.io/devcontainers-extra/features/black:2": {},
+    "ghcr.io/devcontainers-extra/features/coverage-py:2": {},
+    "ghcr.io/devcontainers-extra/features/isort:2": {},
+    "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
+    "ghcr.io/devcontainers-extra/features/zsh-plugins:0": {},
     "ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
     "ghcr.io/guiyomh/features/vim:0": {},
     "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/devcontainers-contrib/features/act:1": {},
+    "ghcr.io/devcontainers-extra/features/act:1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },

--- a/predict_occultation/Dockerfile
+++ b/predict_occultation/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm-slim as base
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH
 
-# Instalacao do Gfortran 7 e Miniconda
+# Instalacao do Gfortran 12 e Miniconda
 RUN set -x && \
     # \
     apt-get update --fix-missing && \
@@ -41,13 +41,13 @@ FROM base as praia_occ
 COPY praia_occ_src /tmp/praia_occ_src
 RUN mkdir /tmp/praia_occ \
     && cd /tmp/praia_occ_src \
-    && gfortran geradata.f -o geradata spicelib.a \
+    && gfortran-12 geradata.f -o geradata spicelib.a \
     && mv geradata /tmp/praia_occ \
-    && gfortran elimina.f -o elimina \
+    && gfortran-12 elimina.f -o elimina \
     && mv elimina /tmp/praia_occ \
-    && gfortran PRAIA_occ_star_search_12.f -o PRAIA_occ_star_search_12 \
+    && gfortran-12 PRAIA_occ_star_search_12.f -o PRAIA_occ_star_search_12 \
     && mv PRAIA_occ_star_search_12 /tmp/praia_occ \
-    # 	&& gfortran-7 gerapositions.f -o gerapositions \
+    # 	&& gfortran-12 gerapositions.f -o gerapositions \
     # 	&& mv gerapositions /usr/local/bin/ \
     && cd ~/ \
     && rm -r /tmp/praia_occ_src

--- a/predict_occultation/Dockerfile
+++ b/predict_occultation/Dockerfile
@@ -38,7 +38,7 @@ RUN groupadd -r ton --gid 15010 \
 
 # -------------- PRAIA OCC compile Stage --------------
 FROM base as praia_occ
-ADD praia_occ_src /tmp/praia_occ_src
+COPY praia_occ_src /tmp/praia_occ_src
 RUN mkdir /tmp/praia_occ \
     && cd /tmp/praia_occ_src \
     && gfortran geradata.f -o geradata spicelib.a \

--- a/predict_occultation/Dockerfile
+++ b/predict_occultation/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x && \
     apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
     gcc \
-    gfortran \
+    gfortran-12 \
     ca-certificates \
     git \
     ssh \

--- a/predict_occultation/Dockerfile
+++ b/predict_occultation/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim as base
+FROM debian:bookworm-slim as base
 # FROM ubuntu:20.04 as base
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
@@ -6,15 +6,22 @@ ENV PATH /opt/conda/bin:$PATH
 
 # Instalacao do Gfortran 7 e Miniconda
 RUN set -x && \
+    # SOBRESCREVE sources.list para usar repositórios arquivados do BUSTER
+    # echo "deb [trusted=yes] http://archive.debian.org/debian buster main non-free contrib" > /etc/apt/sources.list && \
+    # echo "deb-src [trusted=yes] http://archive.debian.org/debian buster main non-free contrib" >> /etc/apt/sources.list && \
+    # echo "deb [trusted=yes] http://archive.debian.org/debian-security buster/updates main non-free contrib" >> /etc/apt/sources.list && \
+    # \
     apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \
     gcc \
-    gfortran-7 \
+    gfortran \
     ca-certificates \
     git \
     ssh \
     wget \
     rsync \
+    procps \
+    build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /opt/conda \
@@ -38,11 +45,11 @@ FROM base as praia_occ
 ADD praia_occ_src /tmp/praia_occ_src
 RUN mkdir /tmp/praia_occ \
     && cd /tmp/praia_occ_src \
-    && gfortran-7 geradata.f -o geradata spicelib.a \
+    && gfortran geradata.f -o geradata spicelib.a \
     && mv geradata /tmp/praia_occ \
-    && gfortran-7 elimina.f -o elimina \
+    && gfortran elimina.f -o elimina \
     && mv elimina /tmp/praia_occ \
-    && gfortran-7 PRAIA_occ_star_search_12.f -o PRAIA_occ_star_search_12 \
+    && gfortran PRAIA_occ_star_search_12.f -o PRAIA_occ_star_search_12 \
     && mv PRAIA_occ_star_search_12 /tmp/praia_occ \
     # 	&& gfortran-7 gerapositions.f -o gerapositions \
     # 	&& mv gerapositions /usr/local/bin/ \

--- a/predict_occultation/Dockerfile
+++ b/predict_occultation/Dockerfile
@@ -6,10 +6,6 @@ ENV PATH /opt/conda/bin:$PATH
 
 # Instalacao do Gfortran 7 e Miniconda
 RUN set -x && \
-    # SOBRESCREVE sources.list para usar repositórios arquivados do BUSTER
-    # echo "deb [trusted=yes] http://archive.debian.org/debian buster main non-free contrib" > /etc/apt/sources.list && \
-    # echo "deb-src [trusted=yes] http://archive.debian.org/debian buster main non-free contrib" >> /etc/apt/sources.list && \
-    # echo "deb [trusted=yes] http://archive.debian.org/debian-security buster/updates main non-free contrib" >> /etc/apt/sources.list && \
     # \
     apt-get update --fix-missing && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
### Summary
Upgrades `spicelib.a` from 32-bit to 64-bit version to ensure compatibility with latest GFortran compiler versions.

### Changes
- **Library upgrade**: Replace 32-bit `spicelib.a` with 64-bit version
- **Docker update**: Update prediction occultation container Dockerfile to support the new library version

### Impact
- ✅ Resolves compatibility issues with modern GFortran compilers
- ✅ Maintains existing functionality while supporting newer development environments
- ✅ Future-proofs the codebase for continued development