### PR TITLE
Validação baseada em schema e upsert com staging via COPY na ingestão de ocultações

### DIFF
--- a/predict_occultation/src/asteroid/asteroid.py
+++ b/predict_occultation/src/asteroid/asteroid.py
@@ -1,5 +1,6 @@
 import configparser
 import datetime
+import functools
 import json
 import logging
 import os
@@ -16,21 +17,25 @@ from asteroid.jpl import findSPKID, get_asteroid_uncertainty_from_jpl, get_bsp_f
 from dao import AsteroidDao, ObservationDao, OccultationDao
 from library import date_to_jd, dec2DMS, has_expired, ra2HMS
 
-# Colunas NOT NULL no banco (tno_occultation) que validamos no ingest.
-# Apenas as que existirem no DataFrame são usadas.
-INGEST_NOT_NULL_COLUMNS = [
-    "date_time",
-    "ra_star_candidate",
-    "dec_star_candidate",
-    "ra_target",
-    "dec_target",
-    "closest_approach",
-    "position_angle",
-    "velocity",
-    "delta",
-    "g",
-    "long",
-]
+
+@functools.lru_cache(maxsize=1)
+def _get_ingest_not_null_columns():
+    """
+    Resolve colunas NOT NULL da tabela tno_occultation via schema.
+    Opera em modo fail-fast: se não conseguir resolver, lança erro explícito.
+    """
+    try:
+        dao = OccultationDao()
+        schema_cols = tuple(col.name for col in dao.tbl.columns if not col.nullable)
+        if not schema_cols:
+            raise RuntimeError(
+                "SchemaResolutionError: no NOT NULL columns found for tno_occultation."
+            )
+        return schema_cols
+    except Exception as e:
+        raise RuntimeError(
+            f"SchemaResolutionError: unable to resolve NOT NULL columns for tno_occultation. {e}"
+        ) from e
 
 
 def _validate_ingest_dataframe(df, job_id, asteroid_name):
@@ -64,10 +69,25 @@ def _validate_ingest_dataframe(df, job_id, asteroid_name):
             )
         return df.iloc[0:0], failures, True
 
-    # Colunas NOT NULL que existem no DataFrame (numéricas serão coercidas)
-    not_null_cols = [c for c in INGEST_NOT_NULL_COLUMNS if c in df.columns]
-    if not not_null_cols:
-        return df, [], False
+    # hash_id é obrigatório para manter a semântica de upsert.
+    if "hash_id" not in df.columns:
+        for idx, row in df.iterrows():
+            event_id = str(row.get("gaia_source_id", row.get("date_time", idx)))
+            date_time_val = row.get("date_time", "")
+            failures.append(
+                {
+                    "job_id": job_id,
+                    "asteroid": asteroid_name,
+                    "event_id": event_id,
+                    "date_time": date_time_val,
+                    "reason": "missing required column hash_id for upsert",
+                    "error_type": "MissingHashIdColumn",
+                }
+            )
+        return df.iloc[0:0], failures, False
+
+    # Colunas NOT NULL obtidas do schema que existem no DataFrame
+    not_null_cols = [c for c in _get_ingest_not_null_columns() if c in df.columns]
 
     # Colunas NOT NULL que são string: null ou vazio/whitespace = inválido
     string_not_null = [
@@ -76,6 +96,7 @@ def _validate_ingest_dataframe(df, job_id, asteroid_name):
         "dec_star_candidate",
         "ra_target",
         "dec_target",
+        "hash_id",
     ]
     # Coerção numérica para colunas que devem ser float
     numeric_not_null = [
@@ -99,6 +120,8 @@ def _validate_ingest_dataframe(df, job_id, asteroid_name):
             valid_mask &= df[col].notna() & (df[col].astype(str).str.strip() != "")
         else:
             valid_mask &= df[col].notna()
+    # hash_id é obrigatório por regra de negócio do upsert
+    valid_mask &= df["hash_id"].notna() & (df["hash_id"].astype(str).str.strip() != "")
 
     invalid_mask = ~valid_mask
     if invalid_mask.any():
@@ -110,6 +133,8 @@ def _validate_ingest_dataframe(df, job_id, asteroid_name):
                 if pd.isna(row.get(c))
                 or (c in string_not_null and str(row.get(c, "")).strip() == "")
             ]
+            if pd.isna(row.get("hash_id")) or str(row.get("hash_id", "")).strip() == "":
+                bad_cols.append("hash_id")
             reason = (
                 "; ".join(f"{c} null or empty" for c in bad_cols)
                 if bad_cols
@@ -905,7 +930,25 @@ class Asteroid:
                     % (asteroid_name, len(failures))
                 )
             else:
-                rowcount = dao.upinsert_occultations(df_valid, conn=conn)
+                ingest_mode = os.getenv("INGEST_UPSERT_MODE", "to_sql").strip().lower()
+                if ingest_mode == "copy_staging":
+                    if conn is None:
+                        log.warning(
+                            "Asteroid [%s] copy_staging requested but no DB connection was provided; using to_sql fallback."
+                            % asteroid_name
+                        )
+                        rowcount = dao.upinsert_occultations(df_valid, conn=conn)
+                    else:
+                        rowcount = dao.upinsert_occultations_copy_staging(
+                            df_valid, conn=conn
+                        )
+                else:
+                    rowcount = dao.upinsert_occultations(df_valid, conn=conn)
+
+                log.info(
+                    "Asteroid [%s] Ingest upsert mode [%s]."
+                    % (asteroid_name, ingest_mode)
+                )
                 # pandas to_sql(method=...) pode retornar None; usar len(df_valid) como fallback
                 if rowcount is None:
                     rowcount = len(df_valid)

--- a/predict_occultation/src/dao/occultation.py
+++ b/predict_occultation/src/dao/occultation.py
@@ -1,8 +1,11 @@
 # from sqlalchemy.dialects import postgresql
+import io
+import uuid
+
 import pandas as pd
 from dao.db_base import DBBase
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.sql import and_, delete
+from sqlalchemy.sql import and_, delete, text
 
 
 def occultations_upsert(table, conn, keys, data_iter):
@@ -81,11 +84,10 @@ class OccultationDao(DBBase):
         return rowcount
 
     def upinsert_occultations(self, df, conn=None):
-        # Add updated_at column
-        df["updated_at"] = pd.to_datetime("now", utc=True)
+        prepared = self._prepare_upsert_dataframe(df)
 
         if conn is not None:
-            rowcount = df.to_sql(
+            rowcount = prepared.to_sql(
                 "tno_occultation",
                 con=conn,
                 if_exists="append",
@@ -96,7 +98,7 @@ class OccultationDao(DBBase):
 
         engine = self.get_db_engine()
         with engine.connect() as conn:
-            rowcount = df.to_sql(
+            rowcount = prepared.to_sql(
                 "tno_occultation",
                 con=conn,
                 if_exists="append",
@@ -104,3 +106,106 @@ class OccultationDao(DBBase):
                 index=False,
             )
             return rowcount
+
+    def _prepare_upsert_dataframe(self, df):
+        """Apply audit timestamp policy used by all upsert paths."""
+        now_utc = pd.to_datetime("now", utc=True)
+        prepared = df.copy()
+        prepared["updated_at"] = now_utc
+        if "created_at" not in prepared.columns:
+            prepared["created_at"] = now_utc
+        return prepared
+
+    @staticmethod
+    def _quote_sql_identifier(name):
+        """Quote SQL identifiers used in dynamic COPY/UPSERT statements."""
+        return f'"{str(name).replace(chr(34), chr(34) * 2)}"'
+
+    def _copy_dataframe_to_temp_table(self, conn, tmp_table, prepared, insert_columns):
+        quoted_insert_columns = [
+            self._quote_sql_identifier(col) for col in insert_columns
+        ]
+        copy_columns_sql = ", ".join(quoted_insert_columns)
+        copy_sql = (
+            f"COPY {self._quote_sql_identifier(tmp_table)} ({copy_columns_sql}) "
+            "FROM STDIN WITH (FORMAT CSV, NULL '\\N')"
+        )
+        copy_buffer = io.StringIO()
+        prepared.loc[:, insert_columns].to_csv(
+            copy_buffer,
+            index=False,
+            header=False,
+            na_rep="\\N",
+        )
+        copy_buffer.seek(0)
+
+        dbapi_connection = conn.connection
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.copy_expert(copy_sql, copy_buffer)
+        finally:
+            cursor.close()
+
+    def _upsert_from_temp_table(self, conn, tmp_table, insert_columns, update_columns):
+        quoted_insert_columns = [
+            self._quote_sql_identifier(col) for col in insert_columns
+        ]
+        insert_columns_sql = ", ".join(quoted_insert_columns)
+        select_columns_sql = ", ".join(quoted_insert_columns)
+        if not update_columns:
+            upsert_sql = (
+                f"INSERT INTO {self._quote_sql_identifier('tno_occultation')} ({insert_columns_sql}) "
+                f"SELECT {select_columns_sql} FROM {self._quote_sql_identifier(tmp_table)} "
+                "ON CONFLICT ON CONSTRAINT tno_occultation_hash_id_key DO NOTHING"
+            )
+            result = conn.execute(text(upsert_sql))
+            return result.rowcount
+
+        update_set_sql = ", ".join(
+            f"{self._quote_sql_identifier(col)} = EXCLUDED.{self._quote_sql_identifier(col)}"
+            for col in update_columns
+        )
+        # Skip no-op updates to reduce WAL/lock pressure while preserving idempotency.
+        update_where_sql = " OR ".join(
+            f"{self._quote_sql_identifier('tno_occultation')}.{self._quote_sql_identifier(col)} "
+            f"IS DISTINCT FROM EXCLUDED.{self._quote_sql_identifier(col)}"
+            for col in update_columns
+        )
+        upsert_sql = (
+            f"INSERT INTO {self._quote_sql_identifier('tno_occultation')} ({insert_columns_sql}) "
+            f"SELECT {select_columns_sql} FROM {self._quote_sql_identifier(tmp_table)} "
+            "ON CONFLICT ON CONSTRAINT tno_occultation_hash_id_key "
+            f"DO UPDATE SET {update_set_sql} "
+            f"WHERE {update_where_sql}"
+        )
+        result = conn.execute(text(upsert_sql))
+        return result.rowcount
+
+    def upinsert_occultations_copy_staging(self, df, conn):
+        if df is None or df.empty:
+            return 0
+
+        prepared = self._prepare_upsert_dataframe(df)
+        target_columns = [col.name for col in self.tbl.columns]
+        insert_columns = [col for col in target_columns if col in prepared.columns]
+        if "hash_id" not in insert_columns:
+            raise ValueError("Column 'hash_id' is required for copy_staging upsert.")
+
+        # created_at is immutable; updated_at must be refreshed every upsert.
+        update_columns = [
+            col for col in insert_columns if col not in ("hash_id", "created_at")
+        ]
+        if "updated_at" not in update_columns and "updated_at" in insert_columns:
+            update_columns.append("updated_at")
+
+        tmp_table = f"tmp_tno_occultation_{uuid.uuid4().hex[:12]}"
+        conn.execute(
+            text(
+                f"CREATE TEMP TABLE {tmp_table} AS "
+                "SELECT * FROM tno_occultation WITH NO DATA"
+            )
+        )
+        self._copy_dataframe_to_temp_table(conn, tmp_table, prepared, insert_columns)
+        return self._upsert_from_temp_table(
+            conn, tmp_table, insert_columns, update_columns
+        )

--- a/predict_occultation/src/run.sh
+++ b/predict_occultation/src/run.sh
@@ -25,7 +25,7 @@ echo "=========================================================="
 # Parsl tasks run on the same node (same TMPDIR would cause one task
 # to remove the dir while another still uses it). With hundreds of
 # concurrent tasks, collisions were happening.
-TMPDIR=run_$$
+TMPDIR=`echo $RANDOM | md5sum | head -c 10; echo;`
 export DIR_DATA=/tmp/$TMPDIR
 echo 'DIR_DATA: '$DIR_DATA
 


### PR DESCRIPTION
O pull request altera o processo de ingestão e upsert de ocultações com validação baseada no schema do banco, exigência explícita da coluna `hash_id` para operações de upsert e inclusão de um modo de ingestão que usa `COPY` do PostgreSQL com tabela temporária de staging antes do upsert na tabela principal. A lista de colunas `NOT NULL` passa a ser resolvida dinamicamente a partir do schema da tabela `tno_occultation`. Foram adicionados métodos auxiliares no `OccultationDao` para preparação de dataframes com timestamps de auditoria, citação de identificadores SQL e execução do fluxo de staging. A definição de `created_at` e `updated_at` foi centralizada em um único método. O script de execução também passou a gerar o diretório temporário com um hash baseado em `$RANDOM`.
