### PR TITLE
Feat/ingest sanitize rollback retry cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ database_subset/
 
 # Parsl Runinfo
 predict_occultation/runinfo
+
+# Cursor / graphify local
+.cursorignore
+graphify-out/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHONUNBUFFERED=1
 # Install Packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    gosu \
     # gcc \
     python3-dev \
     build-essential \
@@ -54,18 +55,21 @@ RUN mkdir -p /usr/src/app \
     /archive/maps \
     /archive/skybot_outputs \
     /logs \
+    /app/cache \
     /.astropy/cache \
     /.config/matplotlib \
-    && chown -R $USER_UID:$USER_GID \
+    && chown -R ${USERUID}:${USERGID} \
     /usr/src/app \
     /archive \
     /logs \
+    /app/cache \
     /.astropy \
     /.config \
     && chmod -R 777 /usr/src/app/django_static \
     && chmod -R g+w  \
     /archive \
     /logs \
+    /app/cache \
     /.astropy \
     /.config
 
@@ -82,8 +86,8 @@ COPY --chmod=0775 ./start_beat.sh /start_beat.sh
 COPY --chmod=0775 ./start_flower.sh /start_flower.sh
 
 
-# Switch to non-priviliged user and run app
-USER $USERNAME
+# O container corre como o user não-root definido em TNO_UID:TNO_GID via docker-compose.
+USER ${USERNAME}
 
 # NÃO adicionar o script /start.sh no entrypoint
 # O /start.sh deve ser adicionado no docker-compose command.

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -7,23 +7,11 @@ set -o pipefail
 # exits if any of your variables is not set
 set -o nounset
 
-# Set umask to ensure group-writable directories (matching predict_occultation pattern)
 umask ug=rwx,o=r
 
 echo "Running Entrypoint.sh"
 
-# Create cache directory
-if [[ -z "$CACHE_DIR" ]]; then
-    echo "CACHE_DIR not set, using default: /app/cache"
-    export CACHE_DIR="/app/cache"
-fi
-
-echo "Cache directory: ${CACHE_DIR}"
-
-echo "Creating cache directory: ${CACHE_DIR}"
-mkdir -p ${CACHE_DIR} || echo "WARNING: Could not create cache directory ${CACHE_DIR}"
-
-# Cache warming: Cartopy baixa para o diretório padrão da biblioteca (não usamos local customizado)
+# Cache warming: Cartopy e Astropy IERS
 echo "Cache warming for backend dependencies (Cartopy uses its default location)"
 
 if ! python3 /usr/src/app/warm_cache.py; then
@@ -33,31 +21,5 @@ if ! python3 /usr/src/app/warm_cache.py; then
 else
     echo "Cache warming completed successfully"
 fi
-
-# postgres_ready() {
-# python << END
-# import sys
-
-# import psycopg2
-
-# try:
-#     psycopg2.connect(
-#         dbname="${SQL_DATABASE}",
-#         user="${SQL_USER}",
-#         password="${SQL_PASSWORD}",
-#         host="${SQL_HOST}",
-#         port="${SQL_PORT}",
-#     )
-# except psycopg2.OperationalError:
-#     sys.exit(-1)
-# sys.exit(0)
-
-# END
-# }
-# until postgres_ready; do
-#     >&2 echo 'Waiting for PostgreSQL to become available...'
-#     sleep 1
-# done
-# >&2 echo 'PostgreSQL is available'
 
 exec "$@"

--- a/backend/warm_cache.py
+++ b/backend/warm_cache.py
@@ -303,7 +303,11 @@ def warm_astropy_cache(
 ) -> bool:
     """
     Warm Astropy IERS cache by downloading finals2000A.all.
-    Use the same cache_dir as the pipeline (e.g. CACHE_DIR) so workers use updated data.
+
+    NÃO manipula arquivos internos do astropy manualmente.
+    O astropy gere o seu próprio cache (download/url/{hash}/contents).
+    Para forçar refresh, apaga-se o diretório inteiro e deixa-se o astropy
+    recriar tudo — sem backups manuais, sem renomeações frágeis.
 
     Args:
         cache_dir: Base directory (e.g. /app/cache); Astropy cache will be cache_dir/astropy.
@@ -323,79 +327,78 @@ def warm_astropy_cache(
         from astropy.utils.iers import IERS_Auto
 
         actual_cache_dir = Path(config.get_cache_dir())
-        download_dir = actual_cache_dir / "download"
-        cache_exists = False
-        is_expired = True
-        age_days = 0.0
-        large_files = []
 
-        if download_dir.exists():
-            all_files = [f for f in download_dir.rglob("*") if f.is_file()]
-            large_files = [f for f in all_files if f.stat().st_size > 1000000]
-            if large_files:
-                cache_file = large_files[0]
-                file_size = cache_file.stat().st_size
-                cache_exists = True
-                is_expired, age_days = check_cache_age(cache_file, max_age_days)
-                logger.info(
-                    f"IERS cache exists: {cache_file.name} ({file_size} bytes, age: {age_days:.1f} days)"
-                )
-                if not force_update and not is_expired:
-                    logger.info("IERS cache still valid, skipping download.")
-                    return True
-                if is_expired:
-                    logger.warning(
-                        f"IERS cache expired (>{max_age_days} days), will update."
+        # Se force_update ou cache expirado, apagar o cache antigo por completo.
+        # O astropy recria a estrutura interna corretamente no IERS_Auto.open().
+        if force_update:
+            if astropy_cache_dir.exists():
+                import shutil
+
+                logger.info("Force update: removing entire astropy cache directory.")
+                shutil.rmtree(str(astropy_cache_dir), ignore_errors=True)
+                astropy_cache_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            # Verificar idade do cache apenas pelo ficheiro mais recente >= 1MB
+            download_dir = actual_cache_dir / "download"
+            if download_dir.exists():
+                all_files = [f for f in download_dir.rglob("*") if f.is_file()]
+                large_files = [f for f in all_files if f.stat().st_size > 1_000_000]
+                if large_files:
+                    cache_file = large_files[0]
+                    is_expired, age_days = check_cache_age(cache_file, max_age_days)
+                    logger.info(
+                        f"IERS cache exists ({cache_file.stat().st_size} bytes, "
+                        f"age: {age_days:.1f} days)"
                     )
+                    if not is_expired:
+                        # Carregar a tabela para verificar predictive data age
+                        try:
+                            iers_table = IERS_Auto.open()
+                            predictive_expired, days_until = (
+                                check_iers_predictive_data_age(iers_table, max_age_days)
+                            )
+                            if not predictive_expired:
+                                logger.info(
+                                    f"IERS cache still valid (predictive data: "
+                                    f"{days_until:.1f} days). Skipping download."
+                                )
+                                return True
+                            logger.warning(
+                                f"IERS predictive data expires in {days_until:.1f} days, "
+                                f"will update."
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"Could not load existing IERS cache: {e}. Will re-download."
+                            )
+                    else:
+                        logger.warning(
+                            f"IERS cache expired (>{max_age_days} days), will update."
+                        )
+                    # Remover cache antigo para forçar re-download limpo
+                    if astropy_cache_dir.exists():
+                        import shutil
 
-        should_force_download = force_update or (cache_exists and is_expired)
-        old_cache_file = None
-        if should_force_download and large_files:
-            old_cache_file = large_files[0]
-            backup_file = old_cache_file.with_suffix(old_cache_file.suffix + ".backup")
-            logger.info(f"Backing up old IERS cache to {backup_file.name}")
-            old_cache_file.rename(backup_file)
-            old_cache_file = backup_file
+                        logger.info("Removing old astropy cache for clean re-download.")
+                        shutil.rmtree(str(astropy_cache_dir), ignore_errors=True)
+                        astropy_cache_dir.mkdir(parents=True, exist_ok=True)
 
-        try:
-            iers_table = IERS_Auto.open()
-            logger.info(f"IERS table loaded. Length: {len(iers_table)}")
-        except Exception as e:
-            if old_cache_file and old_cache_file.exists():
-                logger.warning(f"IERS download failed: {e}. Restoring backup.")
-                orig = old_cache_file.with_suffix("")
-                if old_cache_file.suffix == ".backup":
-                    old_cache_file.rename(orig)
-                    iers_table = IERS_Auto.open()
-                    logger.info("Loaded IERS from restored backup.")
-                else:
-                    raise
-            else:
-                raise
+        # IERS_Auto.open() gere o download e cache internamente.
+        # Não há manipulação manual de ficheiros — o astropy faz tudo.
+        iers_table = IERS_Auto.open()
+        logger.info(f"IERS table loaded. Length: {len(iers_table)}")
 
         predictive_expired, days_until = check_iers_predictive_data_age(
             iers_table, max_age_days
         )
         if predictive_expired:
             logger.warning(
-                f"IERS predictive data expires in {days_until:.1f} days - consider updating again soon."
+                f"IERS predictive data expires in {days_until:.1f} days "
+                f"— consider updating again soon."
             )
         else:
             logger.info(f"IERS predictive data valid for {days_until:.1f} more days.")
 
-        if (
-            old_cache_file
-            and old_cache_file.exists()
-            and old_cache_file.suffix == ".backup"
-        ):
-            new_large = [
-                f
-                for f in download_dir.rglob("*")
-                if f.is_file() and f.stat().st_size > 1000000
-            ]
-            if new_large and new_large[0] != old_cache_file:
-                old_cache_file.unlink()
-                logger.info("Old IERS backup removed.")
         logger.info("Astropy IERS cache warming completed successfully.")
         return True
     except Exception as e:

--- a/compose/local/docker-compose-template.yml
+++ b/compose/local/docker-compose-template.yml
@@ -8,7 +8,7 @@ services:
   # Backend Django
   backend: &backend
     build: ${TNO_PROJ_DIR:-.}/backend
-    user: ${TNO_UID:-31670}:${TNO_GID:-15010}
+    user: "${TNO_UID:-1000}:${TNO_GID:-1000}"
     group_add:
       - "15007"
       - "15010"
@@ -25,8 +25,6 @@ services:
       - ${TNO_PROJ_DIR:-.}/data/cache:/app/cache
     env_file:
       - .env
-    environment:
-      - CACHE_DIR=/app/cache
     command: /start.sh
     depends_on:
       - database

--- a/compose/local/env-template
+++ b/compose/local/env-template
@@ -83,6 +83,7 @@ POSTGRES_DB=${DATABASE_ADMIN_DB}
 # HPC Parsl — Linea (PARSL_*; ver predict_occultation/src/parsl_config.py)
 # -------------------------------------
 PARSL_SLURM_PARTITION=cpu
+PARSL_SLURM_ACCOUNT=hpc-public
 PARSL_LINEA_SMALL_MAX_BLOCKS=1
 PARSL_LINEA_LARGE_MAX_BLOCKS=1
 PARSL_LINEA_SMALL_CORES_PER_NODE=28

--- a/compose/local/env-template
+++ b/compose/local/env-template
@@ -1,5 +1,6 @@
 # Docker Compose
 # -------------------------------------
+# UID/GID do processo Django/uWSGI após o entrypoint (logs e cache ficam graváveis para este utilizador)
 TNO_UID=1000
 TNO_GID=1000
 TNO_PORT=80
@@ -61,6 +62,7 @@ PREDICTION_JOB_AUTO_UPDATE=False
 PARSL_ENV=local
 PREDICT_OUTPUTS=/app/outputs/predict_occultations
 PREDICT_INPUTS=/app/inputs/
+CACHE_DIR=/app/cache
 # DATABASE used Predict Occultation container
 # A configuração é diferente por que o container precisa de rede do tipo host, então ele não reconhece o database.
 # A porta do banco de dados precisa estar exposta para o host.
@@ -78,7 +80,10 @@ POSTGRES_PASSWORD=${DATABASE_ADMIN_PASSWORD}
 POSTGRES_DB=${DATABASE_ADMIN_DB}
 
 
-# HPC Parsl dynamic allocation
+# HPC Parsl — Linea (PARSL_*; ver predict_occultation/src/parsl_config.py)
 # -------------------------------------
-MAX_NODES=24
-ASTEROIDS_PER_NODE=500
+PARSL_SLURM_PARTITION=cpu
+PARSL_LINEA_SMALL_MAX_BLOCKS=1
+PARSL_LINEA_LARGE_MAX_BLOCKS=1
+PARSL_LINEA_SMALL_CORES_PER_NODE=28
+PARSL_LINEA_LARGE_CORES_PER_NODE=52

--- a/compose/production/docker-compose-template.yml
+++ b/compose/production/docker-compose-template.yml
@@ -6,7 +6,7 @@ services:
   backend:
     &backend
     image: linea/tno:backend_${TNO_IMAGE_TAG:-8fa8fae}
-    user: ${TNO_UID:-31670}:${TNO_GID:-15010}
+    user: "${TNO_UID:-31670}:${TNO_GID:-15010}"
     group_add:
       - "15007"
       - "15010"
@@ -17,8 +17,6 @@ services:
       - ${TNO_PROJ_DIR:-.}/data/cache:/app/cache
     env_file:
       - .env
-    environment:
-      - CACHE_DIR=/app/cache
     command: /start.sh
     depends_on:
       - rabbit
@@ -57,8 +55,6 @@ services:
       - ${TNO_PROJ_DIR:-.}/logs:/app/logs
     env_file:
       - .env
-    environment:
-      - CACHE_DIR=/app/cache
 
   # Celery Workers (Tarefas do backend em background)
   celery_worker:

--- a/compose/production/env-template
+++ b/compose/production/env-template
@@ -1,6 +1,7 @@
 # Docker Compose
 # -------------------------------------
 TNO_IMAGE_TAG=teste
+# UID/GID do processo após o entrypoint (imagem deve incluir entrypoint com gosu). O arranque é root só para ajustar logs/cache montados.
 TNO_UID=31670
 TNO_GID=15010
 TNO_SSHKEY=/lustre/t1/scratch/users/app.tno/.ssh/id_rsa
@@ -38,11 +39,15 @@ PARSL_ENV=linea
 REMOTE_PIPELINE_ROOT=${TNO_PROJ_DIR:-.}
 PREDICT_OUTPUTS=${TNO_PROJ_DIR:-.}/data/predict_occultations
 PREDICT_INPUTS=${TNO_PROJ_DIR:-.}/data/asteroids
+CACHE_DIR=/app/cache
 DB_ADMIN_URI=${DB_ADMIN_URI}
 DB_CATALOG_URI=${DB_CATALOG_URI}
 
 
-# HPC Parsl dynamic allocation
+# HPC Parsl — Linea (PARSL_*; ver predict_occultation/src/parsl_config.py)
 # -------------------------------------
-MAX_NODES=24
-ASTEROIDS_PER_NODE=500
+PARSL_SLURM_PARTITION=cpu
+PARSL_LINEA_SMALL_MAX_BLOCKS=16
+PARSL_LINEA_LARGE_MAX_BLOCKS=12
+PARSL_LINEA_SMALL_CORES_PER_NODE=28
+PARSL_LINEA_LARGE_CORES_PER_NODE=52

--- a/compose/production/env-template
+++ b/compose/production/env-template
@@ -47,6 +47,7 @@ DB_CATALOG_URI=${DB_CATALOG_URI}
 # HPC Parsl — Linea (PARSL_*; ver predict_occultation/src/parsl_config.py)
 # -------------------------------------
 PARSL_SLURM_PARTITION=cpu
+PARSL_SLURM_ACCOUNT=hpc-public
 PARSL_LINEA_SMALL_MAX_BLOCKS=16
 PARSL_LINEA_LARGE_MAX_BLOCKS=12
 PARSL_LINEA_SMALL_CORES_PER_NODE=28

--- a/compose/testing/docker-compose-template.yml
+++ b/compose/testing/docker-compose-template.yml
@@ -6,7 +6,7 @@ services:
   backend:
     &backend
     image: linea/tno:backend_${TNO_IMAGE_TAG:-8fa8fae}
-    user: ${TNO_UID:-31670}:${TNO_GID:-15010}
+    user: "${TNO_UID:-31670}:${TNO_GID:-15010}"
     group_add:
       - "15007"
       - "15010"
@@ -17,8 +17,6 @@ services:
       - ${TNO_PROJ_DIR:-.}/data/cache:/app/cache
     env_file:
       - .env
-    environment:
-      - CACHE_DIR=/app/cache
     command: /start.sh
     depends_on:
       - rabbit
@@ -61,8 +59,6 @@ services:
       - ${TNO_PROJ_DIR:-.}/logs:/app/logs
     env_file:
       - .env
-    environment:
-      - CACHE_DIR=/app/cache
 
   # Celery Workers (Tarefas do backend em background)
   celery_worker:

--- a/compose/testing/env-template
+++ b/compose/testing/env-template
@@ -47,6 +47,7 @@ DB_CATALOG_URI=${DB_CATALOG_URI}
 # HPC Parsl — Linea (PARSL_*; ver predict_occultation/src/parsl_config.py)
 # -------------------------------------
 PARSL_SLURM_PARTITION=cpu
+PARSL_SLURM_ACCOUNT=hpc-public
 PARSL_LINEA_SMALL_MAX_BLOCKS=1
 PARSL_LINEA_LARGE_MAX_BLOCKS=1
 PARSL_LINEA_SMALL_CORES_PER_NODE=28

--- a/compose/testing/env-template
+++ b/compose/testing/env-template
@@ -1,6 +1,7 @@
 # Docker Compose
 # -------------------------------------
 TNO_IMAGE_TAG=teste
+# UID/GID após o entrypoint (imagem com gosu). Arranque root só para logs/cache montados.
 TNO_UID=31670
 TNO_GID=15010
 TNO_SSHKEY=/lustre/t1/scratch/users/app.tno/.ssh/id_rsa
@@ -38,11 +39,15 @@ PARSL_ENV=linea
 REMOTE_PIPELINE_ROOT=${TNO_PROJ_DIR:-.}
 PREDICT_OUTPUTS=${TNO_PROJ_DIR:-.}/data/predict_occultations
 PREDICT_INPUTS=${TNO_PROJ_DIR:-.}/data/asteroids
+CACHE_DIR=/app/cache
 DB_ADMIN_URI=${DB_ADMIN_URI}
 DB_CATALOG_URI=${DB_CATALOG_URI}
 
 
-# HPC Parsl dynamic allocation
+# HPC Parsl — Linea (PARSL_*; ver predict_occultation/src/parsl_config.py)
 # -------------------------------------
-MAX_NODES=24
-ASTEROIDS_PER_NODE=500
+PARSL_SLURM_PARTITION=cpu
+PARSL_LINEA_SMALL_MAX_BLOCKS=1
+PARSL_LINEA_LARGE_MAX_BLOCKS=1
+PARSL_LINEA_SMALL_CORES_PER_NODE=28
+PARSL_LINEA_LARGE_CORES_PER_NODE=52

--- a/predict_occultation/entrypoint.sh
+++ b/predict_occultation/entrypoint.sh
@@ -1,34 +1,21 @@
 #!/bin/bash --login
 set -o errexit
+set -o pipefail
+set -o nounset
+
 umask ug=rwx,o=r
 
 # Verifica as variaveis de ambiente
-# Usando o conda interno do container
 echo "Checking mandatory environment variables."
 /opt/conda/bin/python3 /app/check_enviroment.py
 
-# ============================================================
-# CRIAR DIRETÓRIO DE CACHE SEMPRE (antes de qualquer coisa)
-# CACHE_DIR deve ser definido no arquivo .env
-# Este diretório de cache é usado para todos os tipos de cache (Astropy, etc.)
-# ============================================================
 if [[ -z "$CACHE_DIR" ]]; then
     echo "ERROR: CACHE_DIR is not set!"
     echo "       CACHE_DIR must be defined in .env file."
-    echo "       This cache directory is used for all types of cache (Astropy, etc.)"
     exit 1
 fi
 
 echo "Cache directory: ${CACHE_DIR}"
-
-echo "Creating cache directory: ${CACHE_DIR}"
-if [ "$(id -u)" = "0" ]; then
-    mkdir -p ${CACHE_DIR}/astropy
-    chown -R 1000:1000 ${CACHE_DIR} 2>/dev/null || true
-else
-    mkdir -p ${CACHE_DIR} || echo "WARNING: Could not create cache directory ${CACHE_DIR}"
-    mkdir -p ${CACHE_DIR}/astropy || echo "WARNING: Could not create astropy subdirectory"
-fi
 
 if [[ "$PARSL_ENV" = "linea" ]]
 then
@@ -123,9 +110,6 @@ else
         echo "Cache warming completed successfully"
     fi
     echo "============================================================"
-    if [ "$(id -u)" = "0" ]; then
-        chown -R 1000:1000 ${CACHE_DIR} 2>/dev/null || true
-    fi
 fi
 
 # Baixa os arquivos bsp planetary e leap_second caso não existam.

--- a/predict_occultation/src/asteroid/asteroid.py
+++ b/predict_occultation/src/asteroid/asteroid.py
@@ -11,7 +11,10 @@ from datetime import timedelta, timezone
 from io import StringIO
 from typing import List, Optional
 
+import numpy as np
 import pandas as pd
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.sql import sqltypes
 from asteroid.external_inputs import AsteroidExternalInputs
 from asteroid.jpl import findSPKID, get_asteroid_uncertainty_from_jpl, get_bsp_from_jpl
 from dao import AsteroidDao, ObservationDao, OccultationDao
@@ -36,6 +39,49 @@ def _get_ingest_not_null_columns():
         raise RuntimeError(
             f"SchemaResolutionError: unable to resolve NOT NULL columns for tno_occultation. {e}"
         ) from e
+
+
+@functools.lru_cache(maxsize=1)
+def _get_occultation_numeric_column_names():
+    """Nomes de colunas numéricas em tno_occultation (schema), para coerção na ingestão."""
+    dao = OccultationDao()
+    names = []
+    for col in dao.tbl.columns:
+        if isinstance(col.type, sqltypes.Boolean):
+            continue
+        if isinstance(
+            col.type,
+            (
+                sqltypes.Integer,
+                sqltypes.SmallInteger,
+                sqltypes.BigInteger,
+                sqltypes.Float,
+                sqltypes.Numeric,
+                sqltypes.REAL,
+            ),
+        ):
+            names.append(col.name)
+    return tuple(names)
+
+
+def _sanitize_numeric_columns_for_ingest_inplace(df, numeric_column_names):
+    """
+    Substitui strings sentinela (ex.: ****) por NaN e aplica pd.to_numeric nas colunas listadas.
+    Modifica df in-place.
+    """
+    for col in numeric_column_names:
+        if col not in df.columns:
+            continue
+        s = df[col]
+        str_mask = s.map(lambda x: isinstance(x, str))
+        if str_mask.any():
+            str_idx = s.index[str_mask]
+            stripped = s.loc[str_idx].astype(str).str.strip()
+            sentinel = stripped.str.fullmatch(r"\*+").fillna(False)
+            sent_idx = stripped.index[sentinel]
+            if len(sent_idx):
+                df.loc[sent_idx, col] = np.nan
+        df[col] = pd.to_numeric(df[col], errors="coerce")
 
 
 def _validate_ingest_dataframe(df, job_id, asteroid_name):
@@ -86,6 +132,12 @@ def _validate_ingest_dataframe(df, job_id, asteroid_name):
             )
         return df.iloc[0:0], failures, False
 
+    df = df.copy()
+    numeric_names = [
+        c for c in _get_occultation_numeric_column_names() if c in df.columns
+    ]
+    _sanitize_numeric_columns_for_ingest_inplace(df, numeric_names)
+
     # Colunas NOT NULL obtidas do schema que existem no DataFrame
     not_null_cols = [c for c in _get_ingest_not_null_columns() if c in df.columns]
 
@@ -107,7 +159,6 @@ def _validate_ingest_dataframe(df, job_id, asteroid_name):
         "g",
         "long",
     ]
-    df = df.copy()
     for col in not_null_cols:
         if col in numeric_not_null and col in df.columns:
             df[col] = pd.to_numeric(df[col], errors="coerce")
@@ -974,6 +1025,13 @@ class Asteroid:
             self.ingest_occultations.update({"message": msg})
             log.error("Asteroid [%s] %s" % (self.name, msg))
             self.set_failure()
+            if conn is not None:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                if isinstance(e, DBAPIError):
+                    raise
             return 0
 
         finally:

--- a/predict_occultation/src/asteroid/asteroid.py
+++ b/predict_occultation/src/asteroid/asteroid.py
@@ -13,12 +13,12 @@ from typing import List, Optional
 
 import numpy as np
 import pandas as pd
-from sqlalchemy.exc import DBAPIError
-from sqlalchemy.sql import sqltypes
 from asteroid.external_inputs import AsteroidExternalInputs
 from asteroid.jpl import findSPKID, get_asteroid_uncertainty_from_jpl, get_bsp_from_jpl
 from dao import AsteroidDao, ObservationDao, OccultationDao
 from library import date_to_jd, dec2DMS, has_expired, ra2HMS
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.sql import sqltypes
 
 
 @functools.lru_cache(maxsize=1)
@@ -133,6 +133,7 @@ def _validate_ingest_dataframe(df, job_id, asteroid_name):
         return df.iloc[0:0], failures, False
 
     df = df.copy()
+
     numeric_names = [
         c for c in _get_occultation_numeric_column_names() if c in df.columns
     ]
@@ -940,6 +941,27 @@ class Asteroid:
                         "Asteroid [%s] Filtered [%s] rows with have_path_coeff=false."
                         % (asteroid_name, filtered_no_path_coeff)
                     )
+
+            # Limpeza: remove linhas com sentinelas mascaradas (****, ******,
+            # **********) em qualquer coluna, que quebram o COPY/ingest no
+            # PostgreSQL.
+            masked = pd.Series(False, index=df.index)
+            for col in df.columns:
+                masked |= (
+                    df[col].astype(str).str.contains(r"\*{2,}", regex=True, na=False)
+                )
+            if masked.any():
+                n_masked = int(masked.sum())
+                log.info(
+                    "Asteroid [%s] Removed [%s] rows with masked sentinels (****)."
+                    % (asteroid_name, n_masked)
+                )
+                df = df.loc[~masked].copy()
+                if df.empty:
+                    del df
+                    del dao
+                    self.ingest_occultations.update({"count": 0})
+                    return 0
 
             df_valid, failures, skip_insert = _validate_ingest_dataframe(
                 df, job_id, asteroid_name

--- a/predict_occultation/src/parsl_config.py
+++ b/predict_occultation/src/parsl_config.py
@@ -8,6 +8,15 @@ from parsl.launchers import SrunLauncher
 from parsl.providers import LocalProvider, SlurmProvider
 
 
+def _env_int_min_one(name, default):
+    """Lê int positivo (mínimo 1) para max_blocks dos executores linea."""
+    try:
+        v = int(os.getenv(name, str(default)).strip() or str(default))
+    except (ValueError, TypeError):
+        v = default
+    return max(1, v)
+
+
 def get_config(key, jobpath):
     """
     Creates an instance of the Parsl configuration
@@ -83,8 +92,9 @@ def get_config(key, jobpath):
         script_dir.mkdir(parents=True, exist_ok=True)
 
         # Cluster heterogêneo: 16 nós apl[01-16] (28 cores/nó), 12 nós apl[17-28] (52 cores/nó)
-        # init_blocks fixos; max_blocks padrão abaixo — valores efetivos em run_pred_occ.py via
-        # PARSL_LINEA_SMALL_MAX_BLOCKS e PARSL_LINEA_LARGE_MAX_BLOCKS (default 16 e 12).
+        # max_blocks: PARSL_LINEA_SMALL_MAX_BLOCKS (default 16), PARSL_LINEA_LARGE_MAX_BLOCKS (default 12)
+        linea_small_max_blocks = _env_int_min_one("PARSL_LINEA_SMALL_MAX_BLOCKS", 16)
+        linea_large_max_blocks = _env_int_min_one("PARSL_LINEA_LARGE_MAX_BLOCKS", 12)
         channel = SSHChannel(
             hostname="loginapl01",
             username="app.tno",
@@ -133,7 +143,7 @@ def get_config(key, jobpath):
                 cores_per_node=28,
                 init_blocks=1,
                 min_blocks=1,
-                max_blocks=16,
+                max_blocks=linea_small_max_blocks,
             ),
         )
         htex_large = HighThroughputExecutor(
@@ -146,7 +156,7 @@ def get_config(key, jobpath):
                 cores_per_node=52,
                 init_blocks=0,
                 min_blocks=0,
-                max_blocks=12,
+                max_blocks=linea_large_max_blocks,
             ),
         )
         executors = {

--- a/predict_occultation/src/parsl_config.py
+++ b/predict_occultation/src/parsl_config.py
@@ -104,6 +104,8 @@ def get_config(key, jobpath):
         )
         linea_small_max_workers = linea_small_max_blocks * linea_small_cores_per_node
         linea_large_max_workers = linea_large_max_blocks * linea_large_cores_per_node
+        # Slurm --partition (SlurmProvider); default cpu se omitido ou vazio
+        slurm_partition = os.getenv("PARSL_SLURM_PARTITION", "cpu").strip() or "cpu"
         channel = SSHChannel(
             hostname="loginapl01",
             username="app.tno",
@@ -131,7 +133,7 @@ def get_config(key, jobpath):
             },
         )
         provider_common = {
-            "partition": "cpu_long",
+            "partition": slurm_partition,
             "nodes_per_block": 1,
             "cmd_timeout": 240,
             "launcher": SrunLauncher(debug=True, overrides=""),

--- a/predict_occultation/src/parsl_config.py
+++ b/predict_occultation/src/parsl_config.py
@@ -106,6 +106,10 @@ def get_config(key, jobpath):
         linea_large_max_workers = linea_large_max_blocks * linea_large_cores_per_node
         # Slurm --partition (SlurmProvider); default cpu se omitido ou vazio
         slurm_partition = os.getenv("PARSL_SLURM_PARTITION", "cpu").strip() or "cpu"
+        # Slurm --account (SlurmProvider); default hpc-public se omitido ou vazio
+        slurm_account = (
+            os.getenv("PARSL_SLURM_ACCOUNT", "hpc-public").strip() or "hpc-public"
+        )
         channel = SSHChannel(
             hostname="loginapl01",
             username="app.tno",
@@ -134,6 +138,7 @@ def get_config(key, jobpath):
         )
         provider_common = {
             "partition": slurm_partition,
+            "account": slurm_account,
             "nodes_per_block": 1,
             "cmd_timeout": 240,
             "launcher": SrunLauncher(debug=True, overrides=""),

--- a/predict_occultation/src/parsl_config.py
+++ b/predict_occultation/src/parsl_config.py
@@ -91,11 +91,11 @@ def get_config(key, jobpath):
         script_dir = pipeline_root.joinpath("script_dir")
         script_dir.mkdir(parents=True, exist_ok=True)
 
-        # Cluster heterogêneo: 16 nós apl[01-16] (28 cores/nó), 12 nós apl[17-28] (52 cores/nó)
-        # max_blocks: PARSL_LINEA_SMALL_MAX_BLOCKS (16), PARSL_LINEA_LARGE_MAX_BLOCKS (12)
+        # Cluster heterogêneo: até 16 nós apl[01-16], 12 nós apl[17-28] (ajustável por env)
+        # max_blocks: default 1 se PARSL_LINEA_SMALL_MAX_BLOCKS / PARSL_LINEA_LARGE_MAX_BLOCKS omitidos
         # cores_per_node: PARSL_LINEA_SMALL_CORES_PER_NODE (28), PARSL_LINEA_LARGE_CORES_PER_NODE (52)
-        linea_small_max_blocks = _env_int_min_one("PARSL_LINEA_SMALL_MAX_BLOCKS", 16)
-        linea_large_max_blocks = _env_int_min_one("PARSL_LINEA_LARGE_MAX_BLOCKS", 12)
+        linea_small_max_blocks = _env_int_min_one("PARSL_LINEA_SMALL_MAX_BLOCKS", 1)
+        linea_large_max_blocks = _env_int_min_one("PARSL_LINEA_LARGE_MAX_BLOCKS", 1)
         linea_small_cores_per_node = _env_int_min_one(
             "PARSL_LINEA_SMALL_CORES_PER_NODE", 28
         )

--- a/predict_occultation/src/parsl_config.py
+++ b/predict_occultation/src/parsl_config.py
@@ -8,13 +8,14 @@ from parsl.launchers import SrunLauncher
 from parsl.providers import LocalProvider, SlurmProvider
 
 
-def _env_int_min_one(name, default):
-    """Lê int positivo (mínimo 1) para max_blocks e cores_per_node (executores linea)."""
+def _env_int_min_zero(name, default):
+    """Lê int não-negativo (mínimo 0) para max_blocks e cores_per_node (executores linea).
+    Valor 0 desabilita o executor correspondente."""
     try:
         v = int(os.getenv(name, str(default)).strip() or str(default))
     except (ValueError, TypeError):
         v = default
-    return max(1, v)
+    return max(0, v)
 
 
 def get_config(key, jobpath):
@@ -94,12 +95,13 @@ def get_config(key, jobpath):
         # Cluster heterogêneo: até 16 nós apl[01-16], 12 nós apl[17-28] (ajustável por env)
         # max_blocks: default 1 se PARSL_LINEA_SMALL_MAX_BLOCKS / PARSL_LINEA_LARGE_MAX_BLOCKS omitidos
         # cores_per_node: PARSL_LINEA_SMALL_CORES_PER_NODE (28), PARSL_LINEA_LARGE_CORES_PER_NODE (52)
-        linea_small_max_blocks = _env_int_min_one("PARSL_LINEA_SMALL_MAX_BLOCKS", 1)
-        linea_large_max_blocks = _env_int_min_one("PARSL_LINEA_LARGE_MAX_BLOCKS", 1)
-        linea_small_cores_per_node = _env_int_min_one(
+        # Use 0 para desabilitar um executor específico (útil quando a partição Slurm não cobre certos nós)
+        linea_small_max_blocks = _env_int_min_zero("PARSL_LINEA_SMALL_MAX_BLOCKS", 1)
+        linea_large_max_blocks = _env_int_min_zero("PARSL_LINEA_LARGE_MAX_BLOCKS", 1)
+        linea_small_cores_per_node = _env_int_min_zero(
             "PARSL_LINEA_SMALL_CORES_PER_NODE", 28
         )
-        linea_large_cores_per_node = _env_int_min_one(
+        linea_large_cores_per_node = _env_int_min_zero(
             "PARSL_LINEA_LARGE_CORES_PER_NODE", 52
         )
         linea_small_max_workers = linea_small_max_blocks * linea_small_cores_per_node
@@ -148,34 +150,47 @@ def get_config(key, jobpath):
             "channel": channel,
         }
         # Parsl: max_workers = max_blocks * cores_per_node (1 nó por bloco)
-        htex_small = HighThroughputExecutor(
-            label="linea_small",
-            worker_logdir_root=str(script_dir),
-            max_workers=linea_small_max_workers,
-            provider=SlurmProvider(
-                **provider_common,
-                scheduler_options="#SBATCH --nodelist=apl[01-16]\n",
-                cores_per_node=linea_small_cores_per_node,
-                init_blocks=1,
-                min_blocks=1,
-                max_blocks=linea_small_max_blocks,
-            ),
-        )
-        htex_large = HighThroughputExecutor(
-            label="linea_large",
-            worker_logdir_root=str(script_dir),
-            max_workers=linea_large_max_workers,
-            provider=SlurmProvider(
-                **provider_common,
-                scheduler_options="#SBATCH --nodelist=apl[17-28]\n",
-                cores_per_node=linea_large_cores_per_node,
-                init_blocks=0,
-                min_blocks=0,
-                max_blocks=linea_large_max_blocks,
-            ),
-        )
+        # Executor só é criado se max_blocks > 0 E cores_per_node > 0
+        # Isso permite desabilitar um executor definindo seus valores como 0 no .env
+        linea_executors = []
+        if linea_small_max_blocks > 0 and linea_small_cores_per_node > 0:
+            htex_small = HighThroughputExecutor(
+                label="linea_small",
+                worker_logdir_root=str(script_dir),
+                max_workers=linea_small_max_workers,
+                provider=SlurmProvider(
+                    **provider_common,
+                    scheduler_options="#SBATCH --nodelist=apl[01-16]\n",
+                    cores_per_node=linea_small_cores_per_node,
+                    init_blocks=1,
+                    min_blocks=1,
+                    max_blocks=linea_small_max_blocks,
+                ),
+            )
+            linea_executors.append(htex_small)
+        if linea_large_max_blocks > 0 and linea_large_cores_per_node > 0:
+            htex_large = HighThroughputExecutor(
+                label="linea_large",
+                worker_logdir_root=str(script_dir),
+                max_workers=linea_large_max_workers,
+                provider=SlurmProvider(
+                    **provider_common,
+                    scheduler_options="#SBATCH --nodelist=apl[17-28]\n",
+                    cores_per_node=linea_large_cores_per_node,
+                    init_blocks=0,
+                    min_blocks=0,
+                    max_blocks=linea_large_max_blocks,
+                ),
+            )
+            linea_executors.append(htex_large)
+        if not linea_executors:
+            raise RuntimeError(
+                "No LineA executors configured. "
+                "At least one of PARSL_LINEA_SMALL_MAX_BLOCKS or PARSL_LINEA_LARGE_MAX_BLOCKS "
+                "must be > 0 with corresponding CORES_PER_NODE > 0."
+            )
         executors = {
-            "linea": [htex_small, htex_large],
+            "linea": linea_executors,
         }
 
     if parsl_env == "local":

--- a/predict_occultation/src/parsl_config.py
+++ b/predict_occultation/src/parsl_config.py
@@ -83,7 +83,8 @@ def get_config(key, jobpath):
         script_dir.mkdir(parents=True, exist_ok=True)
 
         # Cluster heterogêneo: 16 nós apl[01-16] (28 cores/nó), 12 nós apl[17-28] (52 cores/nó)
-        # init_blocks/max_blocks sobrescritos em run_pred_occ.py (small=1 no início, large=0)
+        # init_blocks fixos; max_blocks padrão abaixo — valores efetivos em run_pred_occ.py via
+        # PARSL_LINEA_SMALL_MAX_BLOCKS e PARSL_LINEA_LARGE_MAX_BLOCKS (default 16 e 12).
         channel = SSHChannel(
             hostname="loginapl01",
             username="app.tno",

--- a/predict_occultation/src/parsl_config.py
+++ b/predict_occultation/src/parsl_config.py
@@ -9,7 +9,7 @@ from parsl.providers import LocalProvider, SlurmProvider
 
 
 def _env_int_min_one(name, default):
-    """Lê int positivo (mínimo 1) para max_blocks dos executores linea."""
+    """Lê int positivo (mínimo 1) para max_blocks e cores_per_node (executores linea)."""
     try:
         v = int(os.getenv(name, str(default)).strip() or str(default))
     except (ValueError, TypeError):
@@ -92,9 +92,18 @@ def get_config(key, jobpath):
         script_dir.mkdir(parents=True, exist_ok=True)
 
         # Cluster heterogêneo: 16 nós apl[01-16] (28 cores/nó), 12 nós apl[17-28] (52 cores/nó)
-        # max_blocks: PARSL_LINEA_SMALL_MAX_BLOCKS (default 16), PARSL_LINEA_LARGE_MAX_BLOCKS (default 12)
+        # max_blocks: PARSL_LINEA_SMALL_MAX_BLOCKS (16), PARSL_LINEA_LARGE_MAX_BLOCKS (12)
+        # cores_per_node: PARSL_LINEA_SMALL_CORES_PER_NODE (28), PARSL_LINEA_LARGE_CORES_PER_NODE (52)
         linea_small_max_blocks = _env_int_min_one("PARSL_LINEA_SMALL_MAX_BLOCKS", 16)
         linea_large_max_blocks = _env_int_min_one("PARSL_LINEA_LARGE_MAX_BLOCKS", 12)
+        linea_small_cores_per_node = _env_int_min_one(
+            "PARSL_LINEA_SMALL_CORES_PER_NODE", 28
+        )
+        linea_large_cores_per_node = _env_int_min_one(
+            "PARSL_LINEA_LARGE_CORES_PER_NODE", 52
+        )
+        linea_small_max_workers = linea_small_max_blocks * linea_small_cores_per_node
+        linea_large_max_workers = linea_large_max_blocks * linea_large_cores_per_node
         channel = SSHChannel(
             hostname="loginapl01",
             username="app.tno",
@@ -131,16 +140,15 @@ def get_config(key, jobpath):
             "worker_init": f"source {cluster_env_sh}\n",
             "channel": channel,
         }
-        # Parsl 2023.9.25: max_workers é total por executor (não por nó); 448=16*28, 624=12*52
-        # cores_per_node: núcleos físicos por nó (apl01-16: 28, apl17-28: 52)
+        # Parsl: max_workers = max_blocks * cores_per_node (1 nó por bloco)
         htex_small = HighThroughputExecutor(
             label="linea_small",
             worker_logdir_root=str(script_dir),
-            max_workers=448,
+            max_workers=linea_small_max_workers,
             provider=SlurmProvider(
                 **provider_common,
                 scheduler_options="#SBATCH --nodelist=apl[01-16]\n",
-                cores_per_node=28,
+                cores_per_node=linea_small_cores_per_node,
                 init_blocks=1,
                 min_blocks=1,
                 max_blocks=linea_small_max_blocks,
@@ -149,11 +157,11 @@ def get_config(key, jobpath):
         htex_large = HighThroughputExecutor(
             label="linea_large",
             worker_logdir_root=str(script_dir),
-            max_workers=624,
+            max_workers=linea_large_max_workers,
             provider=SlurmProvider(
                 **provider_common,
                 scheduler_options="#SBATCH --nodelist=apl[17-28]\n",
-                cores_per_node=52,
+                cores_per_node=linea_large_cores_per_node,
                 init_blocks=0,
                 min_blocks=0,
                 max_blocks=linea_large_max_blocks,

--- a/predict_occultation/src/run_pred_occ.py
+++ b/predict_occultation/src/run_pred_occ.py
@@ -747,13 +747,30 @@ def submit_tasks(jobid: int):
             # Cluster heterogêneo: small inicia com 1 nó, large com 0 (escala sob demanda)
             parsl_conf.executors[0].provider.init_blocks = 1
             parsl_conf.executors[1].provider.init_blocks = 0
-            parsl_conf.executors[0].provider.max_blocks = 16
-            parsl_conf.executors[1].provider.max_blocks = 12
+            try:
+                small_max_blocks = int(
+                    os.getenv("PARSL_LINEA_SMALL_MAX_BLOCKS", "16").strip() or "16"
+                )
+            except (ValueError, TypeError):
+                small_max_blocks = 16
+            try:
+                large_max_blocks = int(
+                    os.getenv("PARSL_LINEA_LARGE_MAX_BLOCKS", "12").strip() or "12"
+                )
+            except (ValueError, TypeError):
+                large_max_blocks = 12
+            small_max_blocks = max(1, small_max_blocks)
+            large_max_blocks = max(1, large_max_blocks)
+            parsl_conf.executors[0].provider.max_blocks = small_max_blocks
+            parsl_conf.executors[1].provider.max_blocks = large_max_blocks
             log.info(
                 f"Asteroids: {num_asteroids}, Nodes Needed: {nodes_needed}, Max Nodes: {max_nodes}"
             )
             log.info(
-                "Parsl blocks: linea_small init=1 max=16, linea_large init=0 max=12"
+                "Parsl blocks: linea_small init=1 max=%s, linea_large init=0 max=%s "
+                "(env PARSL_LINEA_SMALL_MAX_BLOCKS / PARSL_LINEA_LARGE_MAX_BLOCKS)",
+                small_max_blocks,
+                large_max_blocks,
             )
         else:
             # Um único executor (local ou linea legado)
@@ -767,50 +784,6 @@ def submit_tasks(jobid: int):
                 f"Parsl blocks: init_blocks={parsl_conf.executors[0].provider.init_blocks}, "
                 f"max_blocks={parsl_conf.executors[0].provider.max_blocks}"
             )
-
-        # Limite opcional de workers Parsl (soma dos executores) para reduzir pico no catálogo Gaia.
-        try:
-            cap = int(os.getenv("MAX_CONCURRENT_ASTEROID_TASKS", "0") or "0")
-        except (TypeError, ValueError):
-            cap = 0
-        if cap == 1:
-            log.warning(
-                "MAX_CONCURRENT_ASTEROID_TASKS=1 is invalid for dual executors; ignoring cap."
-            )
-            cap = 0
-        if cap > 0:
-            if envname == "linea" and len(parsl_conf.executors) == 2:
-                s0 = parsl_conf.executors[0].max_workers
-                s1 = parsl_conf.executors[1].max_workers
-                total = s0 + s1
-                if total > cap:
-                    new0 = max(1, int(s0 * cap / total))
-                    new1 = cap - new0
-                    if new1 < 1:
-                        new1 = 1
-                        new0 = cap - 1
-                    parsl_conf.executors[0].max_workers = new0
-                    parsl_conf.executors[1].max_workers = new1
-                    log.info(
-                        "MAX_CONCURRENT_ASTEROID_TASKS=%s scaled Parsl max_workers: "
-                        "linea_small %s->%s, linea_large %s->%s (sum=%s)",
-                        cap,
-                        s0,
-                        new0,
-                        s1,
-                        new1,
-                        new0 + new1,
-                    )
-            elif len(parsl_conf.executors) == 1:
-                ex = parsl_conf.executors[0]
-                if ex.max_workers > cap:
-                    log.info(
-                        "MAX_CONCURRENT_ASTEROID_TASKS=%s capped executor max_workers %s->%s",
-                        cap,
-                        ex.max_workers,
-                        cap,
-                    )
-                    ex.max_workers = cap
 
         parsl.clear()
         parsl.load(parsl_conf)

--- a/predict_occultation/src/run_pred_occ.py
+++ b/predict_occultation/src/run_pred_occ.py
@@ -14,6 +14,13 @@ from io import StringIO
 from pathlib import Path
 from time import sleep
 
+# CRITICAL: Configure cache environment variables BEFORE importing Astropy
+# Astropy reads these variables at import time
+cache_dir_env = os.getenv("CACHE_DIR")
+if cache_dir_env:
+    os.environ["XDG_CACHE_HOME"] = cache_dir_env
+    os.environ["ASTROPY_CACHE_DIR"] = os.path.join(cache_dir_env, "astropy")
+
 import astropy.config as config
 import humanize
 import pandas as pd

--- a/predict_occultation/src/run_pred_occ.py
+++ b/predict_occultation/src/run_pred_occ.py
@@ -752,24 +752,11 @@ def submit_tasks(jobid: int):
 
         if envname == "linea" and len(parsl_conf.executors) == 2:
             # Cluster heterogêneo: small inicia com 1 nó, large com 0 (escala sob demanda)
+            # max_blocks vem de parsl_config.get_config (PARSL_LINEA_*_MAX_BLOCKS)
             parsl_conf.executors[0].provider.init_blocks = 1
             parsl_conf.executors[1].provider.init_blocks = 0
-            try:
-                small_max_blocks = int(
-                    os.getenv("PARSL_LINEA_SMALL_MAX_BLOCKS", "16").strip() or "16"
-                )
-            except (ValueError, TypeError):
-                small_max_blocks = 16
-            try:
-                large_max_blocks = int(
-                    os.getenv("PARSL_LINEA_LARGE_MAX_BLOCKS", "12").strip() or "12"
-                )
-            except (ValueError, TypeError):
-                large_max_blocks = 12
-            small_max_blocks = max(1, small_max_blocks)
-            large_max_blocks = max(1, large_max_blocks)
-            parsl_conf.executors[0].provider.max_blocks = small_max_blocks
-            parsl_conf.executors[1].provider.max_blocks = large_max_blocks
+            small_max_blocks = parsl_conf.executors[0].provider.max_blocks
+            large_max_blocks = parsl_conf.executors[1].provider.max_blocks
             log.info(
                 f"Asteroids: {num_asteroids}, Nodes Needed: {nodes_needed}, Max Nodes: {max_nodes}"
             )

--- a/predict_occultation/src/run_pred_occ.py
+++ b/predict_occultation/src/run_pred_occ.py
@@ -209,9 +209,12 @@ def ingest_predictions(jobid: int):
 
     dao_job_result = PredictOccultationJobResultDao()
     engine = dao_job_result.get_db_engine()
+
+    # Conexão única reutilizada no loop para não saturar o pool (ingestão de
+    # milhares de asteroides). Cada task usa conn.begin() para isolar sua
+    # transação com commit/rollback automáticos.
     conn = engine.connect()
     try:
-        # Get all tasks with status 6 (Ingesting) using shared connection
         tasks = dao_job_result.by_job_id(jobid, status=6, conn=conn)
 
         log.info(f"Tasks to register: {len(tasks)}")
@@ -233,38 +236,31 @@ def ingest_predictions(jobid: int):
                 )
             except Exception as e:
                 log.error("Cannot load asteroid [%s]: %s" % (name, e))
-                try:
-                    conn.rollback()
-                except Exception:
-                    pass
                 fail = {
                     "name": name,
                     "status": 2,
                     "messages": "Failed to load asteroid data: %s" % e,
                 }
-                dao_job_result.update(id=task_id, data=fail, conn=conn)
-                try:
-                    conn.commit()
-                except Exception:
-                    conn.rollback()
+                with conn.begin():
+                    dao_job_result.update(id=task_id, data=fail, conn=conn)
                 continue
 
             attempt = 0
             while True:
                 try:
-                    a.ingest_predictions(conn=conn, job_path=current_path)
-                    consolidated = a.consiladate()
-                    log.info("Updating task with consolidated data")
-                    dao_job_result.update(id=task_id, data=consolidated, conn=conn)
-                    conn.commit()
+                    with conn.begin():
+                        a.ingest_predictions(conn=conn, job_path=current_path)
+                        consolidated = a.consiladate()
+                        log.info("Updating task with consolidated data")
+                        dao_job_result.update(id=task_id, data=consolidated, conn=conn)
                     log.info(f"task updated to status: {consolidated['status']}")
                     break
                 except DBAPIError as e:
-                    try:
-                        conn.rollback()
-                    except Exception:
-                        pass
-                    if _is_insufficient_resources_error(e) and attempt < max_ir_retries - 1:
+                    # conn.begin() já fez rollback automaticamente
+                    if (
+                        _is_insufficient_resources_error(e)
+                        and attempt < max_ir_retries - 1
+                    ):
                         attempt += 1
                         wait_s = ir_backoff * attempt
                         log.warning(
@@ -278,25 +274,16 @@ def ingest_predictions(jobid: int):
                         % (task_id, attempt + 1, e)
                     )
                     consolidated = a.consiladate()
-                    dao_job_result.update(id=task_id, data=consolidated, conn=conn)
-                    try:
-                        conn.commit()
-                    except Exception:
-                        conn.rollback()
+                    with conn.begin():
+                        dao_job_result.update(id=task_id, data=consolidated, conn=conn)
                     break
                 except Exception as e:
-                    try:
-                        conn.rollback()
-                    except Exception:
-                        pass
+                    # conn.begin() já fez rollback automaticamente
                     log.error("Error ingesting task %s: %s" % (task_id, e))
                     traceback.print_exc()
                     consolidated = a.consiladate()
-                    dao_job_result.update(id=task_id, data=consolidated, conn=conn)
-                    try:
-                        conn.commit()
-                    except Exception:
-                        conn.rollback()
+                    with conn.begin():
+                        dao_job_result.update(id=task_id, data=consolidated, conn=conn)
                     break
     finally:
         conn.close()
@@ -730,37 +717,32 @@ def submit_tasks(jobid: int):
 
         # =========================== Parsl ===========================
         log.info("Setting Parsl configurations")
-        # Get configuration parameters from environment variables
         envname = os.getenv("PARSL_ENV", "linea")
-        try:
-            ast_per_node = int(os.getenv("ASTEROIDS_PER_NODE", 28))
-            max_nodes = int(os.getenv("MAX_NODES", 28))
-        except (ValueError, TypeError):
-            log.error("MAX_NODES and ASTEROIDS_PER_NODE must be integers.")
-            exit(1)
-
         num_asteroids = len(asteroids)
-
-        # Dynamically calculate the number of nodes required based on the workload (informativo)
-        if num_asteroids > 0:
-            nodes_needed = math.ceil(num_asteroids / ast_per_node)
-        else:
-            nodes_needed = 0
 
         parsl_conf = get_config(envname, current_path)
         parsl_conf.run_dir = os.path.join(current_path, "runinfo")
 
         if envname == "linea" and len(parsl_conf.executors) == 2:
-            # Cluster heterogêneo: small inicia com 1 nó, large com 0 (escala sob demanda)
-            # max_blocks vem de parsl_config.get_config (PARSL_LINEA_*_MAX_BLOCKS)
-            parsl_conf.executors[0].provider.init_blocks = 1
+            # Cluster heterogêneo: ambos executores iniciam com 0 nós (escala
+            # sob demanda), reduzindo alocação ociosa quando não há asteroids.
+            # Caps (max_blocks) vêm de parsl_config.get_config (PARSL_LINEA_*_MAX_BLOCKS).
+            parsl_conf.executors[0].provider.init_blocks = 0
             parsl_conf.executors[1].provider.init_blocks = 0
             ex0, ex1 = parsl_conf.executors[0], parsl_conf.executors[1]
+            # cores_hint deriva de cores_per_node da config Parsl (fonte única de
+            # verdade), em vez de variáveis de ambiente separadas.
+            cores_hint = ex0.provider.cores_per_node
+            if num_asteroids > 0:
+                nodes_needed = math.ceil(num_asteroids / cores_hint)
+            else:
+                nodes_needed = 0
             log.info(
-                f"Asteroids: {num_asteroids}, Nodes Needed: {nodes_needed}, Max Nodes: {max_nodes}"
+                f"Asteroids: {num_asteroids}, Nodes Needed (≈1 asteroide/core small): "
+                f"{nodes_needed}"
             )
             log.info(
-                "Parsl linea_small: init=1 max_blocks=%s cores_per_node=%s max_workers=%s; "
+                "Parsl linea_small: init=0 max_blocks=%s cores_per_node=%s max_workers=%s; "
                 "linea_large: init=0 max_blocks=%s cores_per_node=%s max_workers=%s "
                 "(PARSL_LINEA_*_MAX_BLOCKS, PARSL_LINEA_*_CORES_PER_NODE)",
                 ex0.provider.max_blocks,
@@ -771,16 +753,26 @@ def submit_tasks(jobid: int):
                 ex1.max_workers,
             )
         else:
-            # Um único executor (local ou linea legado)
+            # Um único executor (local ou linea legado): max_blocks já vem de
+            # parsl_config. cores_hint deriva da config Parsl (cores_per_node ou
+            # fallback max_workers), mantendo única fonte de verdade.
+            ex0 = parsl_conf.executors[0]
             parsl_conf.executors[0].provider.init_blocks = 1
-            if envname == "linea":
-                parsl_conf.executors[0].provider.max_blocks = max_nodes
+            prov = ex0.provider
+            cores_hint = getattr(prov, "cores_per_node", None)
+            if cores_hint is None:
+                cores_hint = max(ex0.max_workers, 1)
+            if num_asteroids > 0:
+                nodes_needed = math.ceil(num_asteroids / cores_hint)
+            else:
+                nodes_needed = 0
             log.info(
-                f"Asteroids: {num_asteroids}, Nodes Needed: {nodes_needed}, Max Nodes: {max_nodes}"
+                f"Asteroids: {num_asteroids}, Nodes Needed (heurística cores): "
+                f"{nodes_needed}"
             )
             log.info(
-                f"Parsl blocks: init_blocks={parsl_conf.executors[0].provider.init_blocks}, "
-                f"max_blocks={parsl_conf.executors[0].provider.max_blocks}"
+                f"Parsl blocks: init_blocks={prov.init_blocks}, "
+                f"max_blocks={prov.max_blocks}"
             )
 
         parsl.clear()
@@ -1256,7 +1248,32 @@ def complete_job(jobid: int):
     if not job["debug"]:
         log.debug("Removing asteroid directory.")
         asteroid_path = pathlib.Path(job["path"]).joinpath("asteroids")
-        shutil.rmtree(asteroid_path)
+        # Verifica existência, tenta shutil.rmtree e faz fallback para rm -rf.
+        # Symlinks, overlay/NFS ou ENOTEMPTY podem falhar com shutil (Python 3.8).
+        # Se ambos falharem, loga warning sem interromper o job.
+        if asteroid_path.exists():
+            try:
+                shutil.rmtree(asteroid_path)
+            except OSError as err:
+                # Mesmo motivo de remove_job_directory: symlinks, overlay/NFS ou
+                # ENOTEMPTY durante rmtree podem falhar com shutil no Python 3.8.
+                log.warning(
+                    "shutil.rmtree falhou (%s); usando rm -rf em [%s]",
+                    err,
+                    asteroid_path,
+                )
+                try:
+                    subprocess.run(
+                        ["rm", "-rf", "--", str(asteroid_path)],
+                        check=True,
+                    )
+                except subprocess.CalledProcessError as rm_err:
+                    log.warning(
+                        "rm -rf tambem falhou (%s); limpando registro apenas. "
+                        "Diretorio [%s] pode precisar de remocao manual.",
+                        rm_err,
+                        asteroid_path,
+                    )
         log.info("Directory of asteroids has been removed!")
 
     log.debug(f"Total Asteroids: [{job['count_asteroids']}]")

--- a/predict_occultation/src/run_pred_occ.py
+++ b/predict_occultation/src/run_pred_occ.py
@@ -755,16 +755,20 @@ def submit_tasks(jobid: int):
             # max_blocks vem de parsl_config.get_config (PARSL_LINEA_*_MAX_BLOCKS)
             parsl_conf.executors[0].provider.init_blocks = 1
             parsl_conf.executors[1].provider.init_blocks = 0
-            small_max_blocks = parsl_conf.executors[0].provider.max_blocks
-            large_max_blocks = parsl_conf.executors[1].provider.max_blocks
+            ex0, ex1 = parsl_conf.executors[0], parsl_conf.executors[1]
             log.info(
                 f"Asteroids: {num_asteroids}, Nodes Needed: {nodes_needed}, Max Nodes: {max_nodes}"
             )
             log.info(
-                "Parsl blocks: linea_small init=1 max=%s, linea_large init=0 max=%s "
-                "(env PARSL_LINEA_SMALL_MAX_BLOCKS / PARSL_LINEA_LARGE_MAX_BLOCKS)",
-                small_max_blocks,
-                large_max_blocks,
+                "Parsl linea_small: init=1 max_blocks=%s cores_per_node=%s max_workers=%s; "
+                "linea_large: init=0 max_blocks=%s cores_per_node=%s max_workers=%s "
+                "(PARSL_LINEA_*_MAX_BLOCKS, PARSL_LINEA_*_CORES_PER_NODE)",
+                ex0.provider.max_blocks,
+                ex0.provider.cores_per_node,
+                ex0.max_workers,
+                ex1.provider.max_blocks,
+                ex1.provider.cores_per_node,
+                ex1.max_workers,
             )
         else:
             # Um único executor (local ou linea legado)

--- a/predict_occultation/src/run_pred_occ.py
+++ b/predict_occultation/src/run_pred_occ.py
@@ -775,6 +775,17 @@ def submit_tasks(jobid: int):
                 f"max_blocks={prov.max_blocks}"
             )
 
+        # Log Slurm partition e account quando submetendo no cluster LineA
+        if envname == "linea":
+            provider = parsl_conf.executors[0].provider
+            slurm_partition = getattr(provider, "partition", "N/A")
+            slurm_account = getattr(provider, "account", "N/A")
+            log.info(
+                "Slurm submission config: partition=%s, account=%s",
+                slurm_partition,
+                slurm_account,
+            )
+
         parsl.clear()
         parsl.load(parsl_conf)
 

--- a/predict_occultation/src/run_pred_occ.py
+++ b/predict_occultation/src/run_pred_occ.py
@@ -39,6 +39,25 @@ except Exception as error:
     raise Exception("Predict Occultation pipeline not installed!")
 
 import parsl
+from sqlalchemy.exc import DBAPIError
+
+
+def _is_insufficient_resources_error(exc):
+    try:
+        from psycopg2 import errors as pg_errors
+    except ImportError:
+        return False
+    cur = exc
+    seen = set()
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, pg_errors.InsufficientResources):
+            return True
+        if isinstance(cur, DBAPIError) and getattr(cur, "orig", None) is not None:
+            cur = cur.orig
+            continue
+        cur = getattr(cur, "__cause__", None)
+    return False
 
 
 class AbortError(Exception):
@@ -178,6 +197,9 @@ def ingest_predictions(jobid: int):
     log.info("-" * 60)
     log.info("Ingest Predictions started")
 
+    max_ir_retries = int(os.getenv("INGEST_INSUFFICIENT_RESOURCES_RETRIES", "3"))
+    ir_backoff = float(os.getenv("INGEST_INSUFFICIENT_RESOURCES_BACKOFF_SECONDS", "2"))
+
     dao_job_result = PredictOccultationJobResultDao()
     engine = dao_job_result.get_db_engine()
     conn = engine.connect()
@@ -193,22 +215,82 @@ def ingest_predictions(jobid: int):
                 f"Registering results for task_id: {task['id']} asteroid_name: {task['name']}"
             )
 
-            # Create Asteroid instance
-            a = Asteroid(
-                name=task["name"],
-                base_path=ASTEROID_PATH,
-                log=log,
-            )
+            task_id = task["id"]
+            name = task["name"]
 
-            # Ingesting predictions in database (reusing same connection)
-            a.ingest_predictions(conn=conn, job_path=current_path)
+            try:
+                a = Asteroid(
+                    name=name,
+                    base_path=ASTEROID_PATH,
+                    log=log,
+                )
+            except Exception as e:
+                log.error("Cannot load asteroid [%s]: %s" % (name, e))
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                fail = {
+                    "name": name,
+                    "status": 2,
+                    "messages": "Failed to load asteroid data: %s" % e,
+                }
+                dao_job_result.update(id=task_id, data=fail, conn=conn)
+                try:
+                    conn.commit()
+                except Exception:
+                    conn.rollback()
+                continue
 
-            # Consolidating asteroid results/errors
-            consolidated = a.consiladate()
-
-            log.info("Updating task with consolidated data")
-            dao_job_result.update(id=task["id"], data=consolidated, conn=conn)
-            log.info(f"task updated to status: {consolidated['status']}")
+            attempt = 0
+            while True:
+                try:
+                    a.ingest_predictions(conn=conn, job_path=current_path)
+                    consolidated = a.consiladate()
+                    log.info("Updating task with consolidated data")
+                    dao_job_result.update(id=task_id, data=consolidated, conn=conn)
+                    conn.commit()
+                    log.info(f"task updated to status: {consolidated['status']}")
+                    break
+                except DBAPIError as e:
+                    try:
+                        conn.rollback()
+                    except Exception:
+                        pass
+                    if _is_insufficient_resources_error(e) and attempt < max_ir_retries - 1:
+                        attempt += 1
+                        wait_s = ir_backoff * attempt
+                        log.warning(
+                            "InsufficientResources for task %s, retry %s/%s after %ss: %s"
+                            % (task_id, attempt, max_ir_retries, wait_s, e)
+                        )
+                        time.sleep(wait_s)
+                        continue
+                    log.error(
+                        "DBAPIError for task %s after %s attempts: %s"
+                        % (task_id, attempt + 1, e)
+                    )
+                    consolidated = a.consiladate()
+                    dao_job_result.update(id=task_id, data=consolidated, conn=conn)
+                    try:
+                        conn.commit()
+                    except Exception:
+                        conn.rollback()
+                    break
+                except Exception as e:
+                    try:
+                        conn.rollback()
+                    except Exception:
+                        pass
+                    log.error("Error ingesting task %s: %s" % (task_id, e))
+                    traceback.print_exc()
+                    consolidated = a.consiladate()
+                    dao_job_result.update(id=task_id, data=consolidated, conn=conn)
+                    try:
+                        conn.commit()
+                    except Exception:
+                        conn.rollback()
+                    break
     finally:
         conn.close()
 
@@ -685,6 +767,50 @@ def submit_tasks(jobid: int):
                 f"Parsl blocks: init_blocks={parsl_conf.executors[0].provider.init_blocks}, "
                 f"max_blocks={parsl_conf.executors[0].provider.max_blocks}"
             )
+
+        # Limite opcional de workers Parsl (soma dos executores) para reduzir pico no catálogo Gaia.
+        try:
+            cap = int(os.getenv("MAX_CONCURRENT_ASTEROID_TASKS", "0") or "0")
+        except (TypeError, ValueError):
+            cap = 0
+        if cap == 1:
+            log.warning(
+                "MAX_CONCURRENT_ASTEROID_TASKS=1 is invalid for dual executors; ignoring cap."
+            )
+            cap = 0
+        if cap > 0:
+            if envname == "linea" and len(parsl_conf.executors) == 2:
+                s0 = parsl_conf.executors[0].max_workers
+                s1 = parsl_conf.executors[1].max_workers
+                total = s0 + s1
+                if total > cap:
+                    new0 = max(1, int(s0 * cap / total))
+                    new1 = cap - new0
+                    if new1 < 1:
+                        new1 = 1
+                        new0 = cap - 1
+                    parsl_conf.executors[0].max_workers = new0
+                    parsl_conf.executors[1].max_workers = new1
+                    log.info(
+                        "MAX_CONCURRENT_ASTEROID_TASKS=%s scaled Parsl max_workers: "
+                        "linea_small %s->%s, linea_large %s->%s (sum=%s)",
+                        cap,
+                        s0,
+                        new0,
+                        s1,
+                        new1,
+                        new0 + new1,
+                    )
+            elif len(parsl_conf.executors) == 1:
+                ex = parsl_conf.executors[0]
+                if ex.max_workers > cap:
+                    log.info(
+                        "MAX_CONCURRENT_ASTEROID_TASKS=%s capped executor max_workers %s->%s",
+                        cap,
+                        ex.max_workers,
+                        cap,
+                    )
+                    ex.max_workers = cap
 
         parsl.clear()
         parsl.load(parsl_conf)

--- a/predict_occultation/src/warm_cache.py
+++ b/predict_occultation/src/warm_cache.py
@@ -133,6 +133,11 @@ def warm_astropy_cache(
     """
     Warm Astropy IERS cache by downloading finals2000A.all.
 
+    NÃO manipula arquivos internos do astropy manualmente.
+    O astropy gere o seu próprio cache (download/url/{hash}/contents).
+    Para forçar refresh, apaga-se o diretório inteiro e deixa-se o astropy
+    recriar tudo — sem backups manuais, sem renomeações frágeis.
+
     Args:
         cache_dir: Directory where cache should be stored
         logger: Logger instance
@@ -147,108 +152,73 @@ def warm_astropy_cache(
 
         astropy_cache_dir = cache_dir / "astropy"
         astropy_cache_dir.mkdir(parents=True, exist_ok=True)
-
         logger.info(f"Warming Astropy cache in: {astropy_cache_dir}")
 
         # Import Astropy AFTER setting environment variables
         import astropy.config as config
         from astropy.utils.iers import IERS_Auto
 
-        # Check if cache already exists before attempting to load
         actual_cache_dir = Path(config.get_cache_dir())
-        download_dir = actual_cache_dir / "download"
-        cache_exists = False
-        is_expired = True  # Default to expired if cache doesn't exist
-        age_days = 0.0
-        large_files = []
 
-        if download_dir.exists():
-            # Find IERS file (typically > 1MB)
-            all_files = [f for f in download_dir.rglob("*") if f.is_file()]
-            large_files = [f for f in all_files if f.stat().st_size > 1000000]
+        # Se force_update ou cache expirado, apagar o cache antigo por completo.
+        # O astropy recria a estrutura interna corretamente no IERS_Auto.open().
+        if force_update:
+            if astropy_cache_dir.exists():
+                import shutil
 
-            if large_files:
-                cache_file = large_files[0]
-                file_size = cache_file.stat().st_size
-                cache_exists = True
-
-                # Check cache age
-                is_expired, age_days = check_cache_age(cache_file, max_age_days)
-
-                logger.info(
-                    f"Cache already exists: {cache_file.relative_to(actual_cache_dir)} ({file_size} bytes, age: {age_days:.1f} days)"
-                )
-
-                if force_update:
-                    logger.info(
-                        "Force update requested - will download latest IERS data"
-                    )
-                elif is_expired:
-                    logger.warning(
-                        f"Cache is expired (age: {age_days:.1f} days > {max_age_days} days) - will update"
-                    )
-                else:
-                    logger.info(
-                        f"Cache is still valid (age: {age_days:.1f} days <= {max_age_days} days)"
-                    )
-                    logger.info("Loading IERS data from existing cache...")
-            else:
-                logger.info(
-                    "Cache directory exists but no IERS file found. Downloading IERS data (finals2000A.all)..."
-                )
+                logger.info("Force update: removing entire astropy cache directory.")
+                shutil.rmtree(str(astropy_cache_dir), ignore_errors=True)
+                astropy_cache_dir.mkdir(parents=True, exist_ok=True)
         else:
-            logger.info(
-                "Cache directory does not exist. Downloading IERS data (finals2000A.all)..."
-            )
-
-        # Determine if we should force download
-        should_force_download = force_update or (cache_exists and is_expired)
-
-        # Store old cache file path for fallback (don't delete until new one is confirmed)
-        old_cache_file = None
-        if should_force_download and cache_exists and large_files:
-            old_cache_file = large_files[0]
-            logger.info(
-                f"Cache update needed - will verify new download before removing old cache"
-            )
-            logger.info(f"Old cache file: {old_cache_file.name} (kept as fallback)")
-
-        # IERS_Auto.open() will use existing cache if available, or download if not
-        # If we need to force update, we'll need to clear the cache AFTER successful download
-        if should_force_download:
-            logger.info("Forcing IERS data update...")
-            # Temporarily rename old cache to force download, but keep it as backup
-            if old_cache_file and old_cache_file.exists():
-                backup_file = old_cache_file.with_suffix(
-                    old_cache_file.suffix + ".backup"
-                )
-                logger.info(f"Temporarily backing up old cache to: {backup_file.name}")
-                old_cache_file.rename(backup_file)
-                old_cache_file = backup_file  # Update reference to backup file
-
-        # Try to download/load IERS data
-        try:
-            iers_table = IERS_Auto.open()
-            logger.info(f"IERS table loaded. Length: {len(iers_table)}")
-        except Exception as e:
-            # If download fails and we have a backup, restore it
-            if old_cache_file and old_cache_file.exists():
-                logger.error(f"Failed to load/update IERS data: {e}")
-                logger.warning("Restoring old cache file as fallback...")
-                # Restore backup
-                original_name = old_cache_file.with_suffix("")
-                if old_cache_file.suffix == ".backup":
-                    old_cache_file.rename(original_name)
-                    logger.info(f"Old cache restored: {original_name.name}")
-                    # Try loading again with restored cache
-                    iers_table = IERS_Auto.open()
+            # Verificar idade do cache apenas pelo ficheiro mais recente >= 1MB
+            download_dir = actual_cache_dir / "download"
+            if download_dir.exists():
+                all_files = [f for f in download_dir.rglob("*") if f.is_file()]
+                large_files = [f for f in all_files if f.stat().st_size > 1_000_000]
+                if large_files:
+                    cache_file = large_files[0]
+                    is_expired, age_days = check_cache_age(cache_file, max_age_days)
                     logger.info(
-                        f"IERS table loaded from restored cache. Length: {len(iers_table)}"
+                        f"IERS cache exists ({cache_file.stat().st_size} bytes, "
+                        f"age: {age_days:.1f} days)"
                     )
-                else:
-                    raise
-            else:
-                raise
+                    if not is_expired:
+                        # Carregar a tabela para verificar predictive data age
+                        try:
+                            iers_table = IERS_Auto.open()
+                            predictive_expired, days_until = (
+                                check_iers_predictive_data_age(iers_table, max_age_days)
+                            )
+                            if not predictive_expired:
+                                logger.info(
+                                    f"IERS cache still valid (predictive data: "
+                                    f"{days_until:.1f} days). Skipping download."
+                                )
+                                return True
+                            logger.warning(
+                                f"IERS predictive data expires in {days_until:.1f} days, "
+                                f"will update."
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"Could not load existing IERS cache: {e}. Will re-download."
+                            )
+                    else:
+                        logger.warning(
+                            f"IERS cache expired (>{max_age_days} days), will update."
+                        )
+                    # Remover cache antigo para forçar re-download limpo
+                    if astropy_cache_dir.exists():
+                        import shutil
+
+                        logger.info("Removing old astropy cache for clean re-download.")
+                        shutil.rmtree(str(astropy_cache_dir), ignore_errors=True)
+                        astropy_cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # IERS_Auto.open() gere o download e cache internamente.
+        # Não há manipulação manual de ficheiros — o astropy faz tudo.
+        iers_table = IERS_Auto.open()
+        logger.info(f"IERS table loaded. Length: {len(iers_table)}")
 
         # Check predictive data age (how far into the future the data predicts)
         predictive_expired, days_until_expiry = check_iers_predictive_data_age(
@@ -264,70 +234,8 @@ def warm_astropy_cache(
                 f"IERS predictive data valid for {days_until_expiry:.1f} more days"
             )
 
-        # Verify cache after loading
-        if download_dir.exists():
-            # Find IERS file (typically > 1MB)
-            all_files = [f for f in download_dir.rglob("*") if f.is_file()]
-            large_files = [f for f in all_files if f.stat().st_size > 1000000]
-
-            if large_files:
-                cache_file = large_files[0]
-                file_size = cache_file.stat().st_size
-
-                # If we successfully downloaded new cache, remove old backup
-                # Only remove backup if we have a NEW cache file (not the backup itself)
-                if (
-                    old_cache_file
-                    and old_cache_file.exists()
-                    and old_cache_file.suffix == ".backup"
-                ):
-                    # Verify new cache is different from old one (by checking it's not the backup)
-                    if cache_file != old_cache_file:
-                        logger.info(
-                            f"New cache verified successfully. Removing old backup: {old_cache_file.name}"
-                        )
-                        old_cache_file.unlink()
-                        logger.info(f"Old cache backup removed successfully")
-                    else:
-                        logger.warning(
-                            "New cache file is same as backup - keeping backup as fallback"
-                        )
-
-                if cache_exists and not should_force_download:
-                    logger.info(
-                        f"Cache verified: {cache_file.relative_to(actual_cache_dir)} ({file_size} bytes)"
-                    )
-                elif should_force_download:
-                    logger.info(
-                        f"Cache updated: {cache_file.relative_to(actual_cache_dir)} ({file_size} bytes)"
-                    )
-                else:
-                    logger.info(
-                        f"Cache file created: {cache_file.relative_to(actual_cache_dir)} ({file_size} bytes)"
-                    )
-                return True
-            else:
-                # No cache file found after download attempt
-                logger.warning(
-                    f"No IERS files found in cache (found {len(all_files)} files total)"
-                )
-        else:
-            # Download directory doesn't exist
-            logger.warning(f"Download directory does not exist: {download_dir}")
-
-        # If we have a backup and no new cache was found, restore it
-        if (
-            old_cache_file
-            and old_cache_file.exists()
-            and old_cache_file.suffix == ".backup"
-        ):
-            logger.warning("Restoring old cache file as fallback...")
-            original_name = old_cache_file.with_suffix("")
-            old_cache_file.rename(original_name)
-            logger.info(f"Old cache restored: {original_name.name}")
-            return True  # Return True because we have restored cache
-
-        return False
+        logger.info("Astropy IERS cache warming completed successfully.")
+        return True
 
     except Exception as e:
         logger.error(f"Astropy cache warming failed: {e}")

--- a/predict_occultation/tests/__init__.py
+++ b/predict_occultation/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for predict_occultation pipeline

--- a/predict_occultation/tests/test_ingest_sanitize.py
+++ b/predict_occultation/tests/test_ingest_sanitize.py
@@ -1,7 +1,6 @@
 import unittest
 
 import pandas as pd
-
 from asteroid.asteroid import _sanitize_numeric_columns_for_ingest_inplace
 
 

--- a/predict_occultation/tests/test_ingest_sanitize.py
+++ b/predict_occultation/tests/test_ingest_sanitize.py
@@ -1,0 +1,35 @@
+import unittest
+
+import pandas as pd
+
+from asteroid.asteroid import _sanitize_numeric_columns_for_ingest_inplace
+
+
+class TestSanitizeNumericIngest(unittest.TestCase):
+    def test_pmdec_sentinel_becomes_nan(self):
+        df = pd.DataFrame(
+            {
+                "hash_id": ["h1"],
+                "pmdec": ["****"],
+                "pmra": [1.0],
+            }
+        )
+        _sanitize_numeric_columns_for_ingest_inplace(df, ["pmdec", "pmra"])
+        self.assertTrue(pd.isna(df.loc[0, "pmdec"]))
+        self.assertAlmostEqual(float(df.loc[0, "pmra"]), 1.0)
+
+    def test_multiple_star_strings_coerced(self):
+        df = pd.DataFrame({"x": ["***", "**", "1.5"]})
+        _sanitize_numeric_columns_for_ingest_inplace(df, ["x"])
+        self.assertTrue(pd.isna(df.loc[0, "x"]))
+        self.assertTrue(pd.isna(df.loc[1, "x"]))
+        self.assertAlmostEqual(float(df.loc[2, "x"]), 1.5)
+
+    def test_numeric_string_preserved(self):
+        df = pd.DataFrame({"y": [" 2.5 "]})
+        _sanitize_numeric_columns_for_ingest_inplace(df, ["y"])
+        self.assertAlmostEqual(float(df.loc[0, "y"]), 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Melhorias na pipeline de predição de ocultações: sanitização dos dados de ingestão de asteroides com rollback/retry, delegação do cache IERS ao astropy, e refinamentos na configuração do Parsl.

**Principais mudanças**
- Sanitização de ingest com rollback/retry — O asteroid.py agora sanitiza os dados antes do COPY/ingest, remove linhas com sentinelas mascaradas que quebravam a ingestão, e utiliza transações via conn.begin() com rollback automático em caso de falha.

- Cache IERS delegado ao astropy — Tanto no backend quanto no predict_occultation, a gestão do cache IERS foi delegada ao astropy, eliminando backups manuais e simplificando os scripts warm_cache.py e entrypoint.sh. O CACHE_DIR é definido antes da importação do Astropy para evitar race conditions.

- Configuração Parsl flexível — A partition do Slurm agora é configurável via PARSL_SLURM_PARTITION (antes hardcoded). Novas variáveis PARSL_LINEA_*_MAX_BLOCKS e PARSL_LINEA_*_CORES_PER_NODE substituem o cap rígido de workers, com defaults seguros (MAX_BLOCKS=1).

- Infraestrutura — O Dockerfile agora cria /app/cache na build, e os entrypoints foram simplificados. Templates de compose e env sincronizados com as novas variáveis.